### PR TITLE
Add identifiers to the class action output.

### DIFF
--- a/D&D_5e_Shaped/D&D_5e.html
+++ b/D&D_5e_Shaped/D&D_5e.html
@@ -2433,7 +2433,7 @@
               </select>
             </div>
             <div class="sheet-col-1-6 sheet-center">
-              <button type='roll' class="sheet-roll" name="roll_classaction1" value="@{output_option} &{template:5eDefault} {{title=@{classactionname1}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname1}}} {{freetext=@{classactionoutput1}}}">
+              <button type='roll' class="sheet-roll" name="roll_classaction1" value="@{output_option} &{template:5eDefault} {{classaction=1}} {{title=@{classactionname1}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname1}}} {{freetext=@{classactionoutput1}}}">
                 <span>Use</span>
               </button>
             </div>
@@ -2682,7 +2682,7 @@
               </select>
             </div>
             <div class="sheet-col-1-6 sheet-center">
-              <button type='roll' class="sheet-roll" name="roll_classaction2" value="@{output_option} &{template:5eDefault} {{title=@{classactionname2}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname2}}} {{freetext=@{classactionoutput2}}}">
+              <button type='roll' class="sheet-roll" name="roll_classaction2" value="@{output_option} &{template:5eDefault} {{{classaction=2}} {title=@{classactionname2}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname2}}} {{freetext=@{classactionoutput2}}}">
                 <span>Use</span>
               </button>
             </div>
@@ -2931,7 +2931,7 @@
               </select>
             </div>
             <div class="sheet-col-1-6 sheet-center">
-              <button type='roll' class="sheet-roll" name="roll_classaction3" value="@{output_option} &{template:5eDefault} {{title=@{classactionname3}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname3}}} {{freetext=@{classactionoutput3}}}">
+              <button type='roll' class="sheet-roll" name="roll_classaction3" value="@{output_option} &{template:5eDefault} {{{classaction=3}} {title=@{classactionname3}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname3}}} {{freetext=@{classactionoutput3}}}">
                 <span>Use</span>
               </button>
             </div>
@@ -3180,7 +3180,7 @@
               </select>
             </div>
             <div class="sheet-col-1-6 sheet-center">
-              <button type='roll' class="sheet-roll" name="roll_classaction4" value="@{output_option} &{template:5eDefault} {{title=@{classactionname4}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname4}}} {{freetext=@{classactionoutput4}}}">
+              <button type='roll' class="sheet-roll" name="roll_classaction4" value="@{output_option} &{template:5eDefault} {{{classaction=4}} {title=@{classactionname4}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname4}}} {{freetext=@{classactionoutput4}}}">
                 <span>Use</span>
               </button>
             </div>
@@ -3429,7 +3429,7 @@
               </select>
             </div>
             <div class="sheet-col-1-6 sheet-center">
-              <button type='roll' class="sheet-roll" name="roll_classaction5" value="@{output_option} &{template:5eDefault} {{title=@{classactionname5}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname5}}} {{freetext=@{classactionoutput5}}}">
+              <button type='roll' class="sheet-roll" name="roll_classaction5" value="@{output_option} &{template:5eDefault} {{{classaction=5}} {title=@{classactionname5}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname5}}} {{freetext=@{classactionoutput5}}}">
                 <span>Use</span>
               </button>
             </div>
@@ -3680,7 +3680,7 @@
               </select>
             </div>
             <div class="sheet-col-1-6 sheet-center">
-              <button type='roll' class="sheet-roll" name="roll_classaction6" value="@{output_option} &{template:5eDefault} {{title=@{classactionname6}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname6}}} {{freetext=@{classactionoutput6}}}">
+              <button type='roll' class="sheet-roll" name="roll_classaction6" value="@{output_option} &{template:5eDefault} {{{classaction=6}} {title=@{classactionname6}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname6}}} {{freetext=@{classactionoutput6}}}">
                 <span>Use</span>
               </button>
             </div>
@@ -3929,7 +3929,7 @@
               </select>
             </div>
             <div class="sheet-col-1-6 sheet-center">
-              <button type='roll' class="sheet-roll" name="roll_classaction7" value="@{output_option} &{template:5eDefault} {{title=@{classactionname7}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname7}}} {{freetext=@{classactionoutput7}}}">
+              <button type='roll' class="sheet-roll" name="roll_classaction7" value="@{output_option} &{template:5eDefault} {{{classaction=7}} {title=@{classactionname7}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname7}}} {{freetext=@{classactionoutput7}}}">
                 <span>Use</span>
               </button>
             </div>
@@ -4178,7 +4178,7 @@
               </select>
             </div>
             <div class="sheet-col-1-6 sheet-center">
-              <button type='roll' class="sheet-roll" name="roll_classaction8" value="@{output_option} &{template:5eDefault} {{title=@{classactionname8}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname8}}} {{freetext=@{classactionoutput8}}}">
+              <button type='roll' class="sheet-roll" name="roll_classaction8" value="@{output_option} &{template:5eDefault} {{{classaction=8}} {title=@{classactionname8}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname8}}} {{freetext=@{classactionoutput8}}}">
                 <span>Use</span>
               </button>
             </div>
@@ -4427,7 +4427,7 @@
               </select>
             </div>
             <div class="sheet-col-1-6 sheet-center">
-              <button type='roll' class="sheet-roll" name="roll_classaction9" value="@{output_option} &{template:5eDefault} {{title=@{classactionname9}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname9}}} {{freetext=@{classactionoutput9}}}">
+              <button type='roll' class="sheet-roll" name="roll_classaction9" value="@{output_option} &{template:5eDefault} {{{classaction=9}} {title=@{classactionname9}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname9}}} {{freetext=@{classactionoutput9}}}">
                 <span>Use</span>
               </button>
             </div>
@@ -4676,7 +4676,7 @@
               </select>
             </div>
             <div class="sheet-col-1-6 sheet-center">
-              <button type='roll' class="sheet-roll" name="roll_classaction10" value="@{output_option} &{template:5eDefault} {{title=@{classactionname10}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname10}}} {{freetext=@{classactionoutput10}}}">
+              <button type='roll' class="sheet-roll" name="roll_classaction10" value="@{output_option} &{template:5eDefault} {{{classaction=10}} {title=@{classactionname10}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname10}}} {{freetext=@{classactionoutput10}}}">
                 <span>Use</span>
               </button>
             </div>
@@ -4927,7 +4927,7 @@
               </select>
             </div>
             <div class="sheet-col-1-6 sheet-center">
-              <button type='roll' class="sheet-roll" name="roll_classaction11" value="@{output_option} &{template:5eDefault} {{title=@{classactionname11}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname11}}} {{freetext=@{classactionoutput11}}}">
+              <button type='roll' class="sheet-roll" name="roll_classaction11" value="@{output_option} &{template:5eDefault} {{{classaction=11}} {title=@{classactionname11}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname11}}} {{freetext=@{classactionoutput11}}}">
                 <span>Use</span>
               </button>
             </div>
@@ -5176,7 +5176,7 @@
               </select>
             </div>
             <div class="sheet-col-1-6 sheet-center">
-              <button type='roll' class="sheet-roll" name="roll_classaction12" value="@{output_option} &{template:5eDefault} {{title=@{classactionname12}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname12}}} {{freetext=@{classactionoutput12}}}">
+              <button type='roll' class="sheet-roll" name="roll_classaction12" value="@{output_option} &{template:5eDefault} {{classaction=12}} {{title=@{classactionname12}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname12}}} {{freetext=@{classactionoutput12}}}">
                 <span>Use</span>
               </button>
             </div>
@@ -5425,7 +5425,7 @@
               </select>
             </div>
             <div class="sheet-col-1-6 sheet-center">
-              <button type='roll' class="sheet-roll" name="roll_classaction13" value="@{output_option} &{template:5eDefault} {{title=@{classactionname13}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname13}}} {{freetext=@{classactionoutput13}}}">
+              <button type='roll' class="sheet-roll" name="roll_classaction13" value="@{output_option} &{template:5eDefault} {{{classaction=13}} {title=@{classactionname13}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname13}}} {{freetext=@{classactionoutput13}}}">
                 <span>Use</span>
               </button>
             </div>
@@ -5674,7 +5674,7 @@
               </select>
             </div>
             <div class="sheet-col-1-6 sheet-center">
-              <button type='roll' class="sheet-roll" name="roll_classaction14" value="@{output_option} &{template:5eDefault} {{title=@{classactionname14}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname14}}} {{freetext=@{classactionoutput14}}}">
+              <button type='roll' class="sheet-roll" name="roll_classaction14" value="@{output_option} &{template:5eDefault} {{{classaction=14}} {title=@{classactionname14}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname14}}} {{freetext=@{classactionoutput14}}}">
                 <span>Use</span>
               </button>
             </div>
@@ -5923,7 +5923,7 @@
               </select>
             </div>
             <div class="sheet-col-1-6 sheet-center">
-              <button type='roll' class="sheet-roll" name="roll_classaction15" value="@{output_option} &{template:5eDefault} {{title=@{classactionname15}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname15}}} {{freetext=@{classactionoutput15}}}">
+              <button type='roll' class="sheet-roll" name="roll_classaction15" value="@{output_option} &{template:5eDefault} {{{classaction=15}} {title=@{classactionname15}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname15}}} {{freetext=@{classactionoutput15}}}">
                 <span>Use</span>
               </button>
             </div>
@@ -6174,7 +6174,7 @@
               </select>
             </div>
             <div class="sheet-col-1-6 sheet-center">
-              <button type='roll' class="sheet-roll" name="roll_classaction16" value="@{output_option} &{template:5eDefault} {{title=@{classactionname16}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname16}}} {{freetext=@{classactionoutput16}}}">
+              <button type='roll' class="sheet-roll" name="roll_classaction16" value="@{output_option} &{template:5eDefault} {{{classaction=16}} {title=@{classactionname16}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname16}}} {{freetext=@{classactionoutput16}}}">
                 <span>Use</span>
               </button>
             </div>
@@ -6423,7 +6423,7 @@
               </select>
             </div>
             <div class="sheet-col-1-6 sheet-center">
-              <button type='roll' class="sheet-roll" name="roll_classaction17" value="@{output_option} &{template:5eDefault} {{title=@{classactionname17}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname17}}} {{freetext=@{classactionoutput17}}}">
+              <button type='roll' class="sheet-roll" name="roll_classaction17" value="@{output_option} &{template:5eDefault} {{{classaction=17}} {title=@{classactionname17}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname17}}} {{freetext=@{classactionoutput17}}}">
                 <span>Use</span>
               </button>
             </div>
@@ -6672,7 +6672,7 @@
               </select>
             </div>
             <div class="sheet-col-1-6 sheet-center">
-              <button type='roll' class="sheet-roll" name="roll_classaction18" value="@{output_option} &{template:5eDefault} {{title=@{classactionname18}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname18}}} {{freetext=@{classactionoutput18}}}">
+              <button type='roll' class="sheet-roll" name="roll_classaction18" value="@{output_option} &{template:5eDefault} {{{classaction=18}} {title=@{classactionname18}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname18}}} {{freetext=@{classactionoutput18}}}">
                 <span>Use</span>
               </button>
             </div>
@@ -6921,7 +6921,7 @@
               </select>
             </div>
             <div class="sheet-col-1-6 sheet-center">
-              <button type='roll' class="sheet-roll" name="roll_classaction19" value="@{output_option} &{template:5eDefault} {{title=@{classactionname19}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname19}}} {{freetext=@{classactionoutput19}}}">
+              <button type='roll' class="sheet-roll" name="roll_classaction19" value="@{output_option} &{template:5eDefault} {{{classaction=19}} {title=@{classactionname19}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname19}}} {{freetext=@{classactionoutput19}}}">
                 <span>Use</span>
               </button>
             </div>
@@ -7170,7 +7170,7 @@
               </select>
             </div>
             <div class="sheet-col-1-6 sheet-center">
-              <button type='roll' class="sheet-roll" name="roll_classaction20" value="@{output_option} &{template:5eDefault} {{title=@{classactionname20}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname20}}} {{freetext=@{classactionoutput20}}}">
+              <button type='roll' class="sheet-roll" name="roll_classaction20" value="@{output_option} &{template:5eDefault} {{{classaction=20}} {title=@{classactionname20}}} {{subheader=@{character_name}}} {{subheaderright=Class/Racial/Other ability}} {{freetextname=@{classactionname20}}} {{freetext=@{classactionoutput20}}}">
                 <span>Use</span>
               </button>
             </div>


### PR DESCRIPTION
This allows for API parsing of the chat messages to interact with the class action. Without this, there is not output in the chat message indicating exactly which class action was used. Since this is merely a new property, users should notice no difference with this change.

Example use case: https://github.com/alienth/mylittlebeholder/blob/master/playerActions.js#L111

Feel free to discard this PR if this type of thing isn't suitable for the sheet.
