### PR TITLE
Rename max hit dice attribute for NPCs.

### DIFF
--- a/D&D_5e_Shaped/D&D_5e.html
+++ b/D&D_5e_Shaped/D&D_5e.html
@@ -1858,7 +1858,7 @@
                   <input type="number" name="attr_hd_d4" min="0" step="1">
                 </div>
                 <div class="sheet-col-1-4 sheet-vert-middle">
-                  <input type="number" name="attr_hd_d4_max">
+                  <input type="number" name="attr_hd_d4_npc_max">
                 </div>
                 <div class="sheet-col-3-10 sheet-center sheet-hd-row sheet-vert-middle">
                   <button type="roll" class="sheet-roll" name="roll_Use_HD_d4" value="@{output_option} &{template:5eDefault} {{title=Spending Hit Dice - d4}} {{subheader=@{character_name}}} {{rollname=HP regained}} {{roll=[[ d4 + @{constitution_mod} ]]}} ]]}} @{classactionhitdice}">
@@ -1875,7 +1875,7 @@
                     <input class="sheet-no-spin" type="number" name="attr_hd_d6_max" value="@{sorcerer_level} + @{wizard_level} + @{custom_classes_d6_hd}" disabled="disabled">
                   </div>
                   <div class="sheet-npc-version">
-                    <input type="number" name="attr_hd_d6_max">
+                    <input type="number" name="attr_hd_d6_npc_max">
                   </div>
                 </div>
                 <div class="sheet-col-3-10 sheet-center sheet-hd-row sheet-vert-middle">
@@ -1893,7 +1893,7 @@
                     <input class="sheet-no-spin" type="number" name="attr_hd_d8_max" value="@{bard_level} + @{cleric_level} + @{druid_level} + @{rogue_level} + @{monk_level} + @{warlock_level} + @{custom_classes_d8_hd}" disabled="disabled">
                   </div>
                   <div class="sheet-npc-version">
-                    <input type="number" name="attr_hd_d8_max">
+                    <input type="number" name="attr_hd_d8_npc_max">
                   </div>
                 </div>
                 <div class="sheet-col-3-10 sheet-center sheet-hd-row sheet-vert-middle">
@@ -1911,7 +1911,7 @@
                     <input class="sheet-no-spin" type="number" name="attr_hd_d10_max" value="@{fighter_level} + @{paladin_level} + @{ranger_level} + @{custom_classes_d10_hd}" disabled="disabled">
                   </div>
                   <div class="sheet-npc-version">
-                    <input type="number" name="attr_hd_d10_max">
+                    <input type="number" name="attr_hd_d10_npc_max">
                   </div>
                 </div>
                 <div class="sheet-col-3-10 sheet-center sheet-hd-row sheet-vert-middle">
@@ -1929,7 +1929,7 @@
                     <input class="sheet-no-spin" type="number" name="attr_hd_d12_max" value="@{barbarian_level} + @{custom_classes_d12_hd}" disabled="disabled">
                   </div>
                   <div class="sheet-npc-version">
-                    <input type="number" name="attr_hd_d12_max">
+                    <input type="number" name="attr_hd_d12_npc_max">
                   </div>
                 </div>
                 <div class="sheet-col-3-10 sheet-center sheet-hd-row sheet-vert-middle">
@@ -1943,7 +1943,7 @@
                   <input type="number" name="attr_hd_d20" min="0" step="1">
                 </div>
                 <div class="sheet-col-1-4 sheet-vert-middle">
-                  <input type="number" name="attr_hd_d20_max">
+                  <input type="number" name="attr_hd_d20_npc_max">
                 </div>
                 <div class="sheet-col-3-10 sheet-center sheet-hd-row sheet-vert-middle">
                   <button type="roll" class="sheet-roll" name="roll_Use_HD_d20" value="@{output_option} &{template:5eDefault} {{title=Spending Hit Dice - d20}} {{subheader=@{character_name}}} {{rollname=HP regained}} {{roll=[[ d20 + @{constitution_mod} ]]}} ]]}} @{classactionhitdice}">

--- a/D&D_5e_Shaped/precompiled/pages/core.html
+++ b/D&D_5e_Shaped/precompiled/pages/core.html
@@ -1652,7 +1652,7 @@
                 <input type="number" name="attr_hd_d4" min="0" step="1">
               </div>
               <div class="sheet-col-1-4 sheet-vert-middle">
-                <input type="number" name="attr_hd_d4_max">
+                <input type="number" name="attr_hd_d4_npc_max">
               </div>
               <div class="sheet-col-3-10 sheet-center sheet-hd-row sheet-vert-middle">
                 <button type="roll" class="sheet-roll" name="roll_Use_HD_d4" value="@{output_option} &{template:5eDefault} {{title=Spending Hit Dice - d4}} {{subheader=@{character_name}}} {{rollname=HP regained}} {{roll=[[ d4 + @{constitution_mod} ]]}} ]]}} @{classactionhitdice}">
@@ -1669,7 +1669,7 @@
                   <input class="sheet-no-spin" type="number" name="attr_hd_d6_max" value="@{sorcerer_level} + @{wizard_level} + @{custom_classes_d6_hd}" disabled="disabled">
                 </div>
                 <div class="sheet-npc-version">
-                  <input type="number" name="attr_hd_d6_max">
+                  <input type="number" name="attr_hd_d6_npc_max">
                 </div>
               </div>
               <div class="sheet-col-3-10 sheet-center sheet-hd-row sheet-vert-middle">
@@ -1687,7 +1687,7 @@
                   <input class="sheet-no-spin" type="number" name="attr_hd_d8_max" value="@{bard_level} + @{cleric_level} + @{druid_level} + @{rogue_level} + @{monk_level} + @{warlock_level} + @{custom_classes_d8_hd}" disabled="disabled">
                 </div>
                 <div class="sheet-npc-version">
-                  <input type="number" name="attr_hd_d8_max">
+                  <input type="number" name="attr_hd_d8_npc_max">
                 </div>
               </div>
               <div class="sheet-col-3-10 sheet-center sheet-hd-row sheet-vert-middle">
@@ -1705,7 +1705,7 @@
                   <input class="sheet-no-spin" type="number" name="attr_hd_d10_max" value="@{fighter_level} + @{paladin_level} + @{ranger_level} + @{custom_classes_d10_hd}" disabled="disabled">
                 </div>
                 <div class="sheet-npc-version">
-                  <input type="number" name="attr_hd_d10_max">
+                  <input type="number" name="attr_hd_d10_npc_max">
                 </div>
               </div>
               <div class="sheet-col-3-10 sheet-center sheet-hd-row sheet-vert-middle">
@@ -1723,7 +1723,7 @@
                   <input class="sheet-no-spin" type="number" name="attr_hd_d12_max" value="@{barbarian_level} + @{custom_classes_d12_hd}" disabled="disabled">
                 </div>
                 <div class="sheet-npc-version">
-                  <input type="number" name="attr_hd_d12_max">
+                  <input type="number" name="attr_hd_d12_npc_max">
                 </div>
               </div>
               <div class="sheet-col-3-10 sheet-center sheet-hd-row sheet-vert-middle">
@@ -1737,7 +1737,7 @@
                 <input type="number" name="attr_hd_d20" min="0" step="1">
               </div>
               <div class="sheet-col-1-4 sheet-vert-middle">
-                <input type="number" name="attr_hd_d20_max">
+                <input type="number" name="attr_hd_d20_npc_max">
               </div>
               <div class="sheet-col-3-10 sheet-center sheet-hd-row sheet-vert-middle">
                 <button type="roll" class="sheet-roll" name="roll_Use_HD_d20" value="@{output_option} &{template:5eDefault} {{title=Spending Hit Dice - d20}} {{subheader=@{character_name}}} {{rollname=HP regained}} {{roll=[[ d20 + @{constitution_mod} ]]}} ]]}} @{classactionhitdice}">


### PR DESCRIPTION
The existence of both an auto-calculated value for players and a static value for NPCs results in the attribute being unfetchable via API or chat commands. Renaming the NPC attr resolves this.

Unfortunately this results in the HD max being effectively reset for all NPC character sheets, so not sure this PR is viable for inclusion in the main sheet :(. If such breakage is unacceptable, feel free to close this PR.
