### PR TITLE
Rename max hit dice attr for players.

### DIFF
--- a/D&D_5e_Shaped/D&D_5e.html
+++ b/D&D_5e_Shaped/D&D_5e.html
@@ -1872,7 +1872,7 @@
                 </div>
                 <div class="sheet-col-1-4 sheet-vert-middle">
                   <div class="sheet-pc-version">
-                    <input class="sheet-no-spin" type="number" name="attr_hd_d6_max" value="@{sorcerer_level} + @{wizard_level} + @{custom_classes_d6_hd}" disabled="disabled">
+                    <input class="sheet-no-spin" type="number" name="attr_hd_d6_player_max" value="@{sorcerer_level} + @{wizard_level} + @{custom_classes_d6_hd}" disabled="disabled">
                   </div>
                   <div class="sheet-npc-version">
                     <input type="number" name="attr_hd_d6_max">
@@ -1890,7 +1890,7 @@
                 </div>
                 <div class="sheet-col-1-4 sheet-vert-middle">
                   <div class="sheet-pc-version">
-                    <input class="sheet-no-spin" type="number" name="attr_hd_d8_max" value="@{bard_level} + @{cleric_level} + @{druid_level} + @{rogue_level} + @{monk_level} + @{warlock_level} + @{custom_classes_d8_hd}" disabled="disabled">
+                    <input class="sheet-no-spin" type="number" name="attr_hd_d8_player_max" value="@{bard_level} + @{cleric_level} + @{druid_level} + @{rogue_level} + @{monk_level} + @{warlock_level} + @{custom_classes_d8_hd}" disabled="disabled">
                   </div>
                   <div class="sheet-npc-version">
                     <input type="number" name="attr_hd_d8_max">
@@ -1908,7 +1908,7 @@
                 </div>
                 <div class="sheet-col-1-4 sheet-vert-middle">
                   <div class="sheet-pc-version">
-                    <input class="sheet-no-spin" type="number" name="attr_hd_d10_max" value="@{fighter_level} + @{paladin_level} + @{ranger_level} + @{custom_classes_d10_hd}" disabled="disabled">
+                    <input class="sheet-no-spin" type="number" name="attr_hd_d10_player_max" value="@{fighter_level} + @{paladin_level} + @{ranger_level} + @{custom_classes_d10_hd}" disabled="disabled">
                   </div>
                   <div class="sheet-npc-version">
                     <input type="number" name="attr_hd_d10_max">
@@ -1926,7 +1926,7 @@
                 </div>
                 <div class="sheet-col-1-4 sheet-vert-middle">
                   <div class="sheet-pc-version">
-                    <input class="sheet-no-spin" type="number" name="attr_hd_d12_max" value="@{barbarian_level} + @{custom_classes_d12_hd}" disabled="disabled">
+                    <input class="sheet-no-spin" type="number" name="attr_hd_d12_player_max" value="@{barbarian_level} + @{custom_classes_d12_hd}" disabled="disabled">
                   </div>
                   <div class="sheet-npc-version">
                     <input type="number" name="attr_hd_d12_max">

--- a/D&D_5e_Shaped/precompiled/pages/core.html
+++ b/D&D_5e_Shaped/precompiled/pages/core.html
@@ -1666,7 +1666,7 @@
               </div>
               <div class="sheet-col-1-4 sheet-vert-middle">
                 <div class="sheet-pc-version">
-                  <input class="sheet-no-spin" type="number" name="attr_hd_d6_max" value="@{sorcerer_level} + @{wizard_level} + @{custom_classes_d6_hd}" disabled="disabled">
+                  <input class="sheet-no-spin" type="number" name="attr_hd_d6_player_max" value="@{sorcerer_level} + @{wizard_level} + @{custom_classes_d6_hd}" disabled="disabled">
                 </div>
                 <div class="sheet-npc-version">
                   <input type="number" name="attr_hd_d6_max">
@@ -1684,7 +1684,7 @@
               </div>
               <div class="sheet-col-1-4 sheet-vert-middle">
                 <div class="sheet-pc-version">
-                  <input class="sheet-no-spin" type="number" name="attr_hd_d8_max" value="@{bard_level} + @{cleric_level} + @{druid_level} + @{rogue_level} + @{monk_level} + @{warlock_level} + @{custom_classes_d8_hd}" disabled="disabled">
+                  <input class="sheet-no-spin" type="number" name="attr_hd_d8_player_max" value="@{bard_level} + @{cleric_level} + @{druid_level} + @{rogue_level} + @{monk_level} + @{warlock_level} + @{custom_classes_d8_hd}" disabled="disabled">
                 </div>
                 <div class="sheet-npc-version">
                   <input type="number" name="attr_hd_d8_max">
@@ -1702,7 +1702,7 @@
               </div>
               <div class="sheet-col-1-4 sheet-vert-middle">
                 <div class="sheet-pc-version">
-                  <input class="sheet-no-spin" type="number" name="attr_hd_d10_max" value="@{fighter_level} + @{paladin_level} + @{ranger_level} + @{custom_classes_d10_hd}" disabled="disabled">
+                  <input class="sheet-no-spin" type="number" name="attr_hd_d10_player_max" value="@{fighter_level} + @{paladin_level} + @{ranger_level} + @{custom_classes_d10_hd}" disabled="disabled">
                 </div>
                 <div class="sheet-npc-version">
                   <input type="number" name="attr_hd_d10_max">
@@ -1720,7 +1720,7 @@
               </div>
               <div class="sheet-col-1-4 sheet-vert-middle">
                 <div class="sheet-pc-version">
-                  <input class="sheet-no-spin" type="number" name="attr_hd_d12_max" value="@{barbarian_level} + @{custom_classes_d12_hd}" disabled="disabled">
+                  <input class="sheet-no-spin" type="number" name="attr_hd_d12_player_max" value="@{barbarian_level} + @{custom_classes_d12_hd}" disabled="disabled">
                 </div>
                 <div class="sheet-npc-version">
                   <input type="number" name="attr_hd_d12_max">


### PR DESCRIPTION
This is a redo of pr #8.

The existing attr name conflicted with the NPC sheet, where the value is static rather than autocalculated. Due to the conflict, the player formula was unfetchable via the API or chat messages. Renaming the attr fixes this.

I initially tried renaming the NPC attr, but since that attr is static and filled in by hand, renaming it would break pre-existing character sheet attributes. The player attribute on the other hand is autocalcuated, and since it was unfetchable due to the conflict it should be unused in any existing macros or API scripts. As such, the player attribute should be safe to rename.
