### PR TITLE
Add optional prompts for cast level and ritual casting for spells.

### DIFF
--- a/D&D_5e_Shaped/D&D_5e.html
+++ b/D&D_5e_Shaped/D&D_5e.html
@@ -13907,8 +13907,14 @@
                   <span class="sheet-german">Effekte</span>
                 </div>
               </div>
+              <div class="sheet-col-1-12 sheet-center">
+                <input type="checkbox" name="attr_spellpromptcastlvl" value="{{spellpromptcastlvl=1}} {{spellcastlvl=?{Would you like to cast @{spellname} at a different level?|@{spellbaselevel}}}}">
+                <div class="sheet-small-label">
+                  <span class="sheet-english">Cast Level Prompt</span>
+                </div>
+              </div>
   
-              <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects}">
+              <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl}">
             </div>
   
             <span class="sheet-spacer"></span>
@@ -14414,8 +14420,14 @@
                   <span class="sheet-german">Effekte</span>
                 </div>
               </div>
+              <div class="sheet-col-1-12 sheet-center">
+                <input type="checkbox" name="attr_spellpromptcastlvl" value="{{spellpromptcastlvl=1}} {{spellcastlvl=?{Would you like to cast @{spellname} at a different level?|@{spellbaselevel}}}}">
+                <div class="sheet-small-label">
+                  <span class="sheet-english">Cast Level Prompt</span>
+                </div>
+              </div>
   
-              <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects}">
+              <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl}">
             </div>
   
             <span class="sheet-spacer"></span>
@@ -14921,8 +14933,14 @@
                   <span class="sheet-german">Effekte</span>
                 </div>
               </div>
+              <div class="sheet-col-1-12 sheet-center">
+                <input type="checkbox" name="attr_spellpromptcastlvl" value="{{spellpromptcastlvl=1}} {{spellcastlvl=?{Would you like to cast @{spellname} at a different level?|@{spellbaselevel}}}}">
+                <div class="sheet-small-label">
+                  <span class="sheet-english">Cast Level Prompt</span>
+                </div>
+              </div>
   
-              <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects}">
+              <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl}">
             </div>
   
             <span class="sheet-spacer"></span>
@@ -15428,8 +15446,14 @@
                   <span class="sheet-german">Effekte</span>
                 </div>
               </div>
+              <div class="sheet-col-1-12 sheet-center">
+                <input type="checkbox" name="attr_spellpromptcastlvl" value="{{spellpromptcastlvl=1}} {{spellcastlvl=?{Would you like to cast @{spellname} at a different level?|@{spellbaselevel}}}}">
+                <div class="sheet-small-label">
+                  <span class="sheet-english">Cast Level Prompt</span>
+                </div>
+              </div>
   
-              <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects}">
+              <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl}">
             </div>
   
             <span class="sheet-spacer"></span>
@@ -15935,8 +15959,14 @@
                   <span class="sheet-german">Effekte</span>
                 </div>
               </div>
+              <div class="sheet-col-1-12 sheet-center">
+                <input type="checkbox" name="attr_spellpromptcastlvl" value="{{spellpromptcastlvl=1}} {{spellcastlvl=?{Would you like to cast @{spellname} at a different level?|@{spellbaselevel}}}}">
+                <div class="sheet-small-label">
+                  <span class="sheet-english">Cast Level Prompt</span>
+                </div>
+              </div>
   
-              <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects}">
+              <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl}">
             </div>
   
             <span class="sheet-spacer"></span>
@@ -16442,8 +16472,14 @@
                   <span class="sheet-german">Effekte</span>
                 </div>
               </div>
+              <div class="sheet-col-1-12 sheet-center">
+                <input type="checkbox" name="attr_spellpromptcastlvl" value="{{spellpromptcastlvl=1}} {{spellcastlvl=?{Would you like to cast @{spellname} at a different level?|@{spellbaselevel}}}}">
+                <div class="sheet-small-label">
+                  <span class="sheet-english">Cast Level Prompt</span>
+                </div>
+              </div>
   
-              <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects}">
+              <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl}">
             </div>
   
             <span class="sheet-spacer"></span>
@@ -16949,8 +16985,14 @@
                   <span class="sheet-german">Effekte</span>
                 </div>
               </div>
+              <div class="sheet-col-1-12 sheet-center">
+                <input type="checkbox" name="attr_spellpromptcastlvl" value="{{spellpromptcastlvl=1}} {{spellcastlvl=?{Would you like to cast @{spellname} at a different level?|@{spellbaselevel}}}}">
+                <div class="sheet-small-label">
+                  <span class="sheet-english">Cast Level Prompt</span>
+                </div>
+              </div>
   
-              <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects}">
+              <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl}">
             </div>
   
             <span class="sheet-spacer"></span>
@@ -17456,8 +17498,14 @@
                   <span class="sheet-german">Effekte</span>
                 </div>
               </div>
+              <div class="sheet-col-1-12 sheet-center">
+                <input type="checkbox" name="attr_spellpromptcastlvl" value="{{spellpromptcastlvl=1}} {{spellcastlvl=?{Would you like to cast @{spellname} at a different level?|@{spellbaselevel}}}}">
+                <div class="sheet-small-label">
+                  <span class="sheet-english">Cast Level Prompt</span>
+                </div>
+              </div>
   
-              <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects}">
+              <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl}">
             </div>
   
             <span class="sheet-spacer"></span>
@@ -17963,8 +18011,14 @@
                   <span class="sheet-german">Effekte</span>
                 </div>
               </div>
+              <div class="sheet-col-1-12 sheet-center">
+                <input type="checkbox" name="attr_spellpromptcastlvl" value="{{spellpromptcastlvl=1}} {{spellcastlvl=?{Would you like to cast @{spellname} at a different level?|@{spellbaselevel}}}}">
+                <div class="sheet-small-label">
+                  <span class="sheet-english">Cast Level Prompt</span>
+                </div>
+              </div>
   
-              <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects}">
+              <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl}">
             </div>
   
             <span class="sheet-spacer"></span>
@@ -18259,6 +18313,7 @@
       </fieldset>
     </div>
   </div>
+  
 
   <div class="sheet-section-inventory sheet-pc-version">
     <h4 class="sheet-center">Coin Carried <span class="sheet-pictos">h</span></h4>
@@ -20657,6 +20712,12 @@
           <div class="sheet-col-15-24 sheet-pad-r-sm sheet-rt-value">{{spelleffect}}</div>
         </div>
       {{/spelleffect}}
+      {{#spellcastlvl}}
+        <div class="sheet-row">
+          <div class="sheet-col-9-24 sheet-pad-l-md sheet-pad-r-md sheet-rt-key">Cast Level</div>
+          <div class="sheet-col-15-24 sheet-pad-r-sm sheet-rt-value">{{spellcastlvl}}</div>
+        </div>
+      {{/spellcastlvl}}
       {{#spellsavesuccess}}
         <div class="sheet-row">
           <div class="sheet-col-9-24 sheet-pad-l-md sheet-pad-r-md sheet-rt-key">Save success</div>
@@ -20763,12 +20824,12 @@
 
       <!-- Class action additions -->
       {{#showclassactions}}
-        {{#allprops() showclassactions character_name save title subheader subheaderright subheader2 subheaderright2 rollname roll rolladv emote deathsave targetAC weapon attack attackadv damage critdamage spell spellconcentration spellritual spellshowinfoblock spellshowdesc spelldescription spellshowhigherlvl spellhigherlevel spellshowattack spellattack spellshowattackadv spellattackadv spellshowsavethrow spellsavedc spellsavestat spellsavesuccess spellshowhealing spellhealing spellshowdamage spelldamage spellcancrit spellcritdamage spellshoweffects spelleffect spellcasttime spellduration spelltarget spellrange spellgainedfrom spellcomponents ability}}
+        {{#allprops() showclassactions character_name save title subheader subheaderright subheader2 subheaderright2 rollname roll rolladv emote deathsave targetAC weapon attack attackadv damage critdamage spell spellconcentration spellritual spellshowinfoblock spellshowdesc spelldescription spellshowhigherlvl spellhigherlevel spellshowattack spellattack spellshowattackadv spellattackadv spellshowsavethrow spellsavedc spellsavestat spellsavesuccess spellshowhealing spellhealing spellshowdamage spelldamage spellcancrit spellcritdamage spellshoweffects spelleffect spellpromptcastlvl spellcastlvl spellcasttime spellduration spelltarget spellrange spellgainedfrom spellcomponents ability}}
           <div class="sheet-row">
             <div class="sheet-col-9-24 sheet-pad-l-md sheet-pad-r-md sheet-rt-key">{{key}}</div>
             <div class="sheet-col-15-24 sheet-pad-r-sm sheet-rt-value">{{value}}</div>
           </div>
-        {{/allprops() showclassactions character_name save title subheader subheaderright subheader2 subheaderright2 rollname roll rolladv emote deathsave targetAC weapon attack attackadv damage critdamage spell spellconcentration spellritual spellshowinfoblock spellshowdesc spelldescription spellshowhigherlvl spellhigherlevel spellshowattack spellattack spellshowattackadv spellattackadv spellshowsavethrow spellsavedc spellsavestat spellsavesuccess spellshowhealing spellhealing spellshowdamage spelldamage spellcancrit spellcritdamage spellshoweffects spelleffect spellcasttime spellduration spelltarget spellrange spellgainedfrom spellcomponents ability}}
+        {{/allprops() showclassactions character_name save title subheader subheaderright subheader2 subheaderright2 rollname roll rolladv emote deathsave targetAC weapon attack attackadv damage critdamage spell spellconcentration spellritual spellshowinfoblock spellshowdesc spelldescription spellshowhigherlvl spellhigherlevel spellshowattack spellattack spellshowattackadv spellattackadv spellshowsavethrow spellsavedc spellsavestat spellsavesuccess spellshowhealing spellhealing spellshowdamage spelldamage spellcancrit spellcritdamage spellshoweffects spelleffect spellpromptcastlvl spellcastlvl spellcasttime spellduration spelltarget spellrange spellgainedfrom spellcomponents ability}}
       {{/showclassactions}}
 
       <!--Outputall-->

--- a/D&D_5e_Shaped/D&D_5e.html
+++ b/D&D_5e_Shaped/D&D_5e.html
@@ -13357,7 +13357,7 @@
                   <span class="sheet-german">Beschreibung</span>
                 </div>
               </div>
-              <div class="sheet-col-1-8 sheet-center">
+              <div class="sheet-col-1-10 sheet-center">
                 <input type="checkbox" name="attr_spellshowhigherlvl" value="{{spellshowhigherlvl=1}} {{spellhigherlevel=@{spellhighersloteffect}}}">
                 <div class="sheet-small-label">
                   <span class="sheet-english">At higher levels</span>
@@ -13372,7 +13372,7 @@
                   <span class="sheet-german">Angriffswurf</span>
                 </div>
               </div>
-              <div class="sheet-col-1-8 sheet-center">
+              <div class="sheet-col-1-10 sheet-center">
                 <input type="checkbox" name="attr_spellshowsavethrow" value="{{spellshowsavethrow=1}} {{spellsavedc=[[@{spellsavedc} + @{customsavedc}]]}} {{spellsavestat=@{savestat}}} {{spellsavesuccess=@{savesuccess}}}">
                 <div class="sheet-small-label">
                   <span class="sheet-english">Saving throw</span>
@@ -13864,7 +13864,7 @@
                   <span class="sheet-german">Beschreibung</span>
                 </div>
               </div>
-              <div class="sheet-col-1-8 sheet-center">
+              <div class="sheet-col-1-10 sheet-center">
                 <input type="checkbox" name="attr_spellshowhigherlvl" value="{{spellshowhigherlvl=1}} {{spellhigherlevel=@{spellhighersloteffect}}}">
                 <div class="sheet-small-label">
                   <span class="sheet-english">At higher levels</span>
@@ -13879,7 +13879,7 @@
                   <span class="sheet-german">Angriffswurf</span>
                 </div>
               </div>
-              <div class="sheet-col-1-8 sheet-center">
+              <div class="sheet-col-1-10 sheet-center">
                 <input type="checkbox" name="attr_spellshowsavethrow" value="{{spellshowsavethrow=1}} {{spellsavedc=[[@{spellsavedc} + @{customsavedc}]]}} {{spellsavestat=@{savestat}}} {{spellsavesuccess=@{savesuccess}}}">
                 <div class="sheet-small-label">
                   <span class="sheet-english">Saving throw</span>
@@ -13913,8 +13913,14 @@
                   <span class="sheet-english">Cast Level Prompt</span>
                 </div>
               </div>
+              <div class="sheet-col-1-12 sheet-center">
+                <input type="checkbox" name="attr_spellpromptritual" value="{{spellpromptritual=1}} {{spellcastritual=?{Would you like to cast @{spellname} as a ritual? (y/n)|n}}}">
+                <div class="sheet-small-label">
+                  <span class="sheet-english">Ritual Prompt</span>
+                </div>
+              </div>
   
-              <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl}">
+              <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl} @{spellpromptritual}">
             </div>
   
             <span class="sheet-spacer"></span>
@@ -14377,7 +14383,7 @@
                   <span class="sheet-german">Beschreibung</span>
                 </div>
               </div>
-              <div class="sheet-col-1-8 sheet-center">
+              <div class="sheet-col-1-10 sheet-center">
                 <input type="checkbox" name="attr_spellshowhigherlvl" value="{{spellshowhigherlvl=1}} {{spellhigherlevel=@{spellhighersloteffect}}}">
                 <div class="sheet-small-label">
                   <span class="sheet-english">At higher levels</span>
@@ -14392,7 +14398,7 @@
                   <span class="sheet-german">Angriffswurf</span>
                 </div>
               </div>
-              <div class="sheet-col-1-8 sheet-center">
+              <div class="sheet-col-1-10 sheet-center">
                 <input type="checkbox" name="attr_spellshowsavethrow" value="{{spellshowsavethrow=1}} {{spellsavedc=[[@{spellsavedc} + @{customsavedc}]]}} {{spellsavestat=@{savestat}}} {{spellsavesuccess=@{savesuccess}}}">
                 <div class="sheet-small-label">
                   <span class="sheet-english">Saving throw</span>
@@ -14426,8 +14432,14 @@
                   <span class="sheet-english">Cast Level Prompt</span>
                 </div>
               </div>
+              <div class="sheet-col-1-12 sheet-center">
+                <input type="checkbox" name="attr_spellpromptritual" value="{{spellpromptritual=1}} {{spellcastritual=?{Would you like to cast @{spellname} as a ritual? (y/n)|n}}}">
+                <div class="sheet-small-label">
+                  <span class="sheet-english">Ritual Prompt</span>
+                </div>
+              </div>
   
-              <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl}">
+              <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl} @{spellpromptritual}">
             </div>
   
             <span class="sheet-spacer"></span>
@@ -14890,7 +14902,7 @@
                   <span class="sheet-german">Beschreibung</span>
                 </div>
               </div>
-              <div class="sheet-col-1-8 sheet-center">
+              <div class="sheet-col-1-10 sheet-center">
                 <input type="checkbox" name="attr_spellshowhigherlvl" value="{{spellshowhigherlvl=1}} {{spellhigherlevel=@{spellhighersloteffect}}}">
                 <div class="sheet-small-label">
                   <span class="sheet-english">At higher levels</span>
@@ -14905,7 +14917,7 @@
                   <span class="sheet-german">Angriffswurf</span>
                 </div>
               </div>
-              <div class="sheet-col-1-8 sheet-center">
+              <div class="sheet-col-1-10 sheet-center">
                 <input type="checkbox" name="attr_spellshowsavethrow" value="{{spellshowsavethrow=1}} {{spellsavedc=[[@{spellsavedc} + @{customsavedc}]]}} {{spellsavestat=@{savestat}}} {{spellsavesuccess=@{savesuccess}}}">
                 <div class="sheet-small-label">
                   <span class="sheet-english">Saving throw</span>
@@ -14939,8 +14951,14 @@
                   <span class="sheet-english">Cast Level Prompt</span>
                 </div>
               </div>
+              <div class="sheet-col-1-12 sheet-center">
+                <input type="checkbox" name="attr_spellpromptritual" value="{{spellpromptritual=1}} {{spellcastritual=?{Would you like to cast @{spellname} as a ritual? (y/n)|n}}}">
+                <div class="sheet-small-label">
+                  <span class="sheet-english">Ritual Prompt</span>
+                </div>
+              </div>
   
-              <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl}">
+              <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl} @{spellpromptritual}">
             </div>
   
             <span class="sheet-spacer"></span>
@@ -15403,7 +15421,7 @@
                   <span class="sheet-german">Beschreibung</span>
                 </div>
               </div>
-              <div class="sheet-col-1-8 sheet-center">
+              <div class="sheet-col-1-10 sheet-center">
                 <input type="checkbox" name="attr_spellshowhigherlvl" value="{{spellshowhigherlvl=1}} {{spellhigherlevel=@{spellhighersloteffect}}}">
                 <div class="sheet-small-label">
                   <span class="sheet-english">At higher levels</span>
@@ -15418,7 +15436,7 @@
                   <span class="sheet-german">Angriffswurf</span>
                 </div>
               </div>
-              <div class="sheet-col-1-8 sheet-center">
+              <div class="sheet-col-1-10 sheet-center">
                 <input type="checkbox" name="attr_spellshowsavethrow" value="{{spellshowsavethrow=1}} {{spellsavedc=[[@{spellsavedc} + @{customsavedc}]]}} {{spellsavestat=@{savestat}}} {{spellsavesuccess=@{savesuccess}}}">
                 <div class="sheet-small-label">
                   <span class="sheet-english">Saving throw</span>
@@ -15452,8 +15470,14 @@
                   <span class="sheet-english">Cast Level Prompt</span>
                 </div>
               </div>
+              <div class="sheet-col-1-12 sheet-center">
+                <input type="checkbox" name="attr_spellpromptritual" value="{{spellpromptritual=1}} {{spellcastritual=?{Would you like to cast @{spellname} as a ritual? (y/n)|n}}}">
+                <div class="sheet-small-label">
+                  <span class="sheet-english">Ritual Prompt</span>
+                </div>
+              </div>
   
-              <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl}">
+              <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl} @{spellpromptritual}">
             </div>
   
             <span class="sheet-spacer"></span>
@@ -15916,7 +15940,7 @@
                   <span class="sheet-german">Beschreibung</span>
                 </div>
               </div>
-              <div class="sheet-col-1-8 sheet-center">
+              <div class="sheet-col-1-10 sheet-center">
                 <input type="checkbox" name="attr_spellshowhigherlvl" value="{{spellshowhigherlvl=1}} {{spellhigherlevel=@{spellhighersloteffect}}}">
                 <div class="sheet-small-label">
                   <span class="sheet-english">At higher levels</span>
@@ -15931,7 +15955,7 @@
                   <span class="sheet-german">Angriffswurf</span>
                 </div>
               </div>
-              <div class="sheet-col-1-8 sheet-center">
+              <div class="sheet-col-1-10 sheet-center">
                 <input type="checkbox" name="attr_spellshowsavethrow" value="{{spellshowsavethrow=1}} {{spellsavedc=[[@{spellsavedc} + @{customsavedc}]]}} {{spellsavestat=@{savestat}}} {{spellsavesuccess=@{savesuccess}}}">
                 <div class="sheet-small-label">
                   <span class="sheet-english">Saving throw</span>
@@ -15965,8 +15989,14 @@
                   <span class="sheet-english">Cast Level Prompt</span>
                 </div>
               </div>
+              <div class="sheet-col-1-12 sheet-center">
+                <input type="checkbox" name="attr_spellpromptritual" value="{{spellpromptritual=1}} {{spellcastritual=?{Would you like to cast @{spellname} as a ritual? (y/n)|n}}}">
+                <div class="sheet-small-label">
+                  <span class="sheet-english">Ritual Prompt</span>
+                </div>
+              </div>
   
-              <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl}">
+              <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl} @{spellpromptritual}">
             </div>
   
             <span class="sheet-spacer"></span>
@@ -16429,7 +16459,7 @@
                   <span class="sheet-german">Beschreibung</span>
                 </div>
               </div>
-              <div class="sheet-col-1-8 sheet-center">
+              <div class="sheet-col-1-10 sheet-center">
                 <input type="checkbox" name="attr_spellshowhigherlvl" value="{{spellshowhigherlvl=1}} {{spellhigherlevel=@{spellhighersloteffect}}}">
                 <div class="sheet-small-label">
                   <span class="sheet-english">At higher levels</span>
@@ -16444,7 +16474,7 @@
                   <span class="sheet-german">Angriffswurf</span>
                 </div>
               </div>
-              <div class="sheet-col-1-8 sheet-center">
+              <div class="sheet-col-1-10 sheet-center">
                 <input type="checkbox" name="attr_spellshowsavethrow" value="{{spellshowsavethrow=1}} {{spellsavedc=[[@{spellsavedc} + @{customsavedc}]]}} {{spellsavestat=@{savestat}}} {{spellsavesuccess=@{savesuccess}}}">
                 <div class="sheet-small-label">
                   <span class="sheet-english">Saving throw</span>
@@ -16478,8 +16508,14 @@
                   <span class="sheet-english">Cast Level Prompt</span>
                 </div>
               </div>
+              <div class="sheet-col-1-12 sheet-center">
+                <input type="checkbox" name="attr_spellpromptritual" value="{{spellpromptritual=1}} {{spellcastritual=?{Would you like to cast @{spellname} as a ritual? (y/n)|n}}}">
+                <div class="sheet-small-label">
+                  <span class="sheet-english">Ritual Prompt</span>
+                </div>
+              </div>
   
-              <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl}">
+              <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl} @{spellpromptritual}">
             </div>
   
             <span class="sheet-spacer"></span>
@@ -16942,7 +16978,7 @@
                   <span class="sheet-german">Beschreibung</span>
                 </div>
               </div>
-              <div class="sheet-col-1-8 sheet-center">
+              <div class="sheet-col-1-10 sheet-center">
                 <input type="checkbox" name="attr_spellshowhigherlvl" value="{{spellshowhigherlvl=1}} {{spellhigherlevel=@{spellhighersloteffect}}}">
                 <div class="sheet-small-label">
                   <span class="sheet-english">At higher levels</span>
@@ -16957,7 +16993,7 @@
                   <span class="sheet-german">Angriffswurf</span>
                 </div>
               </div>
-              <div class="sheet-col-1-8 sheet-center">
+              <div class="sheet-col-1-10 sheet-center">
                 <input type="checkbox" name="attr_spellshowsavethrow" value="{{spellshowsavethrow=1}} {{spellsavedc=[[@{spellsavedc} + @{customsavedc}]]}} {{spellsavestat=@{savestat}}} {{spellsavesuccess=@{savesuccess}}}">
                 <div class="sheet-small-label">
                   <span class="sheet-english">Saving throw</span>
@@ -16991,8 +17027,14 @@
                   <span class="sheet-english">Cast Level Prompt</span>
                 </div>
               </div>
+              <div class="sheet-col-1-12 sheet-center">
+                <input type="checkbox" name="attr_spellpromptritual" value="{{spellpromptritual=1}} {{spellcastritual=?{Would you like to cast @{spellname} as a ritual? (y/n)|n}}}">
+                <div class="sheet-small-label">
+                  <span class="sheet-english">Ritual Prompt</span>
+                </div>
+              </div>
   
-              <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl}">
+              <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl} @{spellpromptritual}">
             </div>
   
             <span class="sheet-spacer"></span>
@@ -17455,7 +17497,7 @@
                   <span class="sheet-german">Beschreibung</span>
                 </div>
               </div>
-              <div class="sheet-col-1-8 sheet-center">
+              <div class="sheet-col-1-10 sheet-center">
                 <input type="checkbox" name="attr_spellshowhigherlvl" value="{{spellshowhigherlvl=1}} {{spellhigherlevel=@{spellhighersloteffect}}}">
                 <div class="sheet-small-label">
                   <span class="sheet-english">At higher levels</span>
@@ -17470,7 +17512,7 @@
                   <span class="sheet-german">Angriffswurf</span>
                 </div>
               </div>
-              <div class="sheet-col-1-8 sheet-center">
+              <div class="sheet-col-1-10 sheet-center">
                 <input type="checkbox" name="attr_spellshowsavethrow" value="{{spellshowsavethrow=1}} {{spellsavedc=[[@{spellsavedc} + @{customsavedc}]]}} {{spellsavestat=@{savestat}}} {{spellsavesuccess=@{savesuccess}}}">
                 <div class="sheet-small-label">
                   <span class="sheet-english">Saving throw</span>
@@ -17504,8 +17546,14 @@
                   <span class="sheet-english">Cast Level Prompt</span>
                 </div>
               </div>
+              <div class="sheet-col-1-12 sheet-center">
+                <input type="checkbox" name="attr_spellpromptritual" value="{{spellpromptritual=1}} {{spellcastritual=?{Would you like to cast @{spellname} as a ritual? (y/n)|n}}}">
+                <div class="sheet-small-label">
+                  <span class="sheet-english">Ritual Prompt</span>
+                </div>
+              </div>
   
-              <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl}">
+              <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl} @{spellpromptritual}">
             </div>
   
             <span class="sheet-spacer"></span>
@@ -17968,7 +18016,7 @@
                   <span class="sheet-german">Beschreibung</span>
                 </div>
               </div>
-              <div class="sheet-col-1-8 sheet-center">
+              <div class="sheet-col-1-10 sheet-center">
                 <input type="checkbox" name="attr_spellshowhigherlvl" value="{{spellshowhigherlvl=1}} {{spellhigherlevel=@{spellhighersloteffect}}}">
                 <div class="sheet-small-label">
                   <span class="sheet-english">At higher levels</span>
@@ -17983,7 +18031,7 @@
                   <span class="sheet-german">Angriffswurf</span>
                 </div>
               </div>
-              <div class="sheet-col-1-8 sheet-center">
+              <div class="sheet-col-1-10 sheet-center">
                 <input type="checkbox" name="attr_spellshowsavethrow" value="{{spellshowsavethrow=1}} {{spellsavedc=[[@{spellsavedc} + @{customsavedc}]]}} {{spellsavestat=@{savestat}}} {{spellsavesuccess=@{savesuccess}}}">
                 <div class="sheet-small-label">
                   <span class="sheet-english">Saving throw</span>
@@ -18017,8 +18065,14 @@
                   <span class="sheet-english">Cast Level Prompt</span>
                 </div>
               </div>
+              <div class="sheet-col-1-12 sheet-center">
+                <input type="checkbox" name="attr_spellpromptritual" value="{{spellpromptritual=1}} {{spellcastritual=?{Would you like to cast @{spellname} as a ritual? (y/n)|n}}}">
+                <div class="sheet-small-label">
+                  <span class="sheet-english">Ritual Prompt</span>
+                </div>
+              </div>
   
-              <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl}">
+              <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl} @{spellpromptritual}">
             </div>
   
             <span class="sheet-spacer"></span>
@@ -18313,7 +18367,6 @@
       </fieldset>
     </div>
   </div>
-  
 
   <div class="sheet-section-inventory sheet-pc-version">
     <h4 class="sheet-center">Coin Carried <span class="sheet-pictos">h</span></h4>
@@ -20718,6 +20771,12 @@
           <div class="sheet-col-15-24 sheet-pad-r-sm sheet-rt-value">{{spellcastlvl}}</div>
         </div>
       {{/spellcastlvl}}
+      {{#spellcastritual}}
+        <div class="sheet-row">
+          <div class="sheet-col-9-24 sheet-pad-l-md sheet-pad-r-md sheet-rt-key">Ritual Cast</div>
+          <div class="sheet-col-15-24 sheet-pad-r-sm sheet-rt-value">{{spellcastritual}}</div>
+        </div>
+      {{/spellcastritual}}
       {{#spellsavesuccess}}
         <div class="sheet-row">
           <div class="sheet-col-9-24 sheet-pad-l-md sheet-pad-r-md sheet-rt-key">Save success</div>
@@ -20824,12 +20883,12 @@
 
       <!-- Class action additions -->
       {{#showclassactions}}
-        {{#allprops() showclassactions character_name save title subheader subheaderright subheader2 subheaderright2 rollname roll rolladv emote deathsave targetAC weapon attack attackadv damage critdamage spell spellconcentration spellritual spellshowinfoblock spellshowdesc spelldescription spellshowhigherlvl spellhigherlevel spellshowattack spellattack spellshowattackadv spellattackadv spellshowsavethrow spellsavedc spellsavestat spellsavesuccess spellshowhealing spellhealing spellshowdamage spelldamage spellcancrit spellcritdamage spellshoweffects spelleffect spellpromptcastlvl spellcastlvl spellcasttime spellduration spelltarget spellrange spellgainedfrom spellcomponents ability}}
+        {{#allprops() showclassactions character_name save title subheader subheaderright subheader2 subheaderright2 rollname roll rolladv emote deathsave targetAC weapon attack attackadv damage critdamage spell spellconcentration spellritual spellshowinfoblock spellshowdesc spelldescription spellshowhigherlvl spellhigherlevel spellshowattack spellattack spellshowattackadv spellattackadv spellshowsavethrow spellsavedc spellsavestat spellsavesuccess spellshowhealing spellhealing spellshowdamage spelldamage spellcancrit spellcritdamage spellshoweffects spelleffect spellpromptcastlvl spellcastlvl spellpromptritual spellcastritual spellcasttime spellduration spelltarget spellrange spellgainedfrom spellcomponents ability}}
           <div class="sheet-row">
             <div class="sheet-col-9-24 sheet-pad-l-md sheet-pad-r-md sheet-rt-key">{{key}}</div>
             <div class="sheet-col-15-24 sheet-pad-r-sm sheet-rt-value">{{value}}</div>
           </div>
-        {{/allprops() showclassactions character_name save title subheader subheaderright subheader2 subheaderright2 rollname roll rolladv emote deathsave targetAC weapon attack attackadv damage critdamage spell spellconcentration spellritual spellshowinfoblock spellshowdesc spelldescription spellshowhigherlvl spellhigherlevel spellshowattack spellattack spellshowattackadv spellattackadv spellshowsavethrow spellsavedc spellsavestat spellsavesuccess spellshowhealing spellhealing spellshowdamage spelldamage spellcancrit spellcritdamage spellshoweffects spelleffect spellpromptcastlvl spellcastlvl spellcasttime spellduration spelltarget spellrange spellgainedfrom spellcomponents ability}}
+        {{/allprops() showclassactions character_name save title subheader subheaderright subheader2 subheaderright2 rollname roll rolladv emote deathsave targetAC weapon attack attackadv damage critdamage spell spellconcentration spellritual spellshowinfoblock spellshowdesc spelldescription spellshowhigherlvl spellhigherlevel spellshowattack spellattack spellshowattackadv spellattackadv spellshowsavethrow spellsavedc spellsavestat spellsavesuccess spellshowhealing spellhealing spellshowdamage spelldamage spellcancrit spellcritdamage spellshoweffects spelleffect spellpromptcastlvl spellcastlvl spellpromptritual spellcastritual spellcasttime spellduration spelltarget spellrange spellgainedfrom spellcomponents ability}}
       {{/showclassactions}}
 
       <!--Outputall-->

--- a/D&D_5e_Shaped/precompiled/pages/roll_template.html
+++ b/D&D_5e_Shaped/precompiled/pages/roll_template.html
@@ -211,6 +211,12 @@
           <div class="sheet-col-15-24 sheet-pad-r-sm sheet-rt-value">{{spelleffect}}</div>
         </div>
       {{/spelleffect}}
+      {{#spellcastlvl}}
+        <div class="sheet-row">
+          <div class="sheet-col-9-24 sheet-pad-l-md sheet-pad-r-md sheet-rt-key">Cast Level</div>
+          <div class="sheet-col-15-24 sheet-pad-r-sm sheet-rt-value">{{spellcastlvl}}</div>
+        </div>
+      {{/spellcastlvl}}
       {{#spellsavesuccess}}
         <div class="sheet-row">
           <div class="sheet-col-9-24 sheet-pad-l-md sheet-pad-r-md sheet-rt-key">Save success</div>
@@ -317,12 +323,12 @@
 
       <!-- Class action additions -->
       {{#showclassactions}}
-        {{#allprops() showclassactions character_name save title subheader subheaderright subheader2 subheaderright2 rollname roll rolladv emote deathsave targetAC weapon attack attackadv damage critdamage spell spellconcentration spellritual spellshowinfoblock spellshowdesc spelldescription spellshowhigherlvl spellhigherlevel spellshowattack spellattack spellshowattackadv spellattackadv spellshowsavethrow spellsavedc spellsavestat spellsavesuccess spellshowhealing spellhealing spellshowdamage spelldamage spellcancrit spellcritdamage spellshoweffects spelleffect spellcasttime spellduration spelltarget spellrange spellgainedfrom spellcomponents ability}}
+        {{#allprops() showclassactions character_name save title subheader subheaderright subheader2 subheaderright2 rollname roll rolladv emote deathsave targetAC weapon attack attackadv damage critdamage spell spellconcentration spellritual spellshowinfoblock spellshowdesc spelldescription spellshowhigherlvl spellhigherlevel spellshowattack spellattack spellshowattackadv spellattackadv spellshowsavethrow spellsavedc spellsavestat spellsavesuccess spellshowhealing spellhealing spellshowdamage spelldamage spellcancrit spellcritdamage spellshoweffects spelleffect spellpromptcastlvl spellcastlvl spellcasttime spellduration spelltarget spellrange spellgainedfrom spellcomponents ability}}
           <div class="sheet-row">
             <div class="sheet-col-9-24 sheet-pad-l-md sheet-pad-r-md sheet-rt-key">{{key}}</div>
             <div class="sheet-col-15-24 sheet-pad-r-sm sheet-rt-value">{{value}}</div>
           </div>
-        {{/allprops() showclassactions character_name save title subheader subheaderright subheader2 subheaderright2 rollname roll rolladv emote deathsave targetAC weapon attack attackadv damage critdamage spell spellconcentration spellritual spellshowinfoblock spellshowdesc spelldescription spellshowhigherlvl spellhigherlevel spellshowattack spellattack spellshowattackadv spellattackadv spellshowsavethrow spellsavedc spellsavestat spellsavesuccess spellshowhealing spellhealing spellshowdamage spelldamage spellcancrit spellcritdamage spellshoweffects spelleffect spellcasttime spellduration spelltarget spellrange spellgainedfrom spellcomponents ability}}
+        {{/allprops() showclassactions character_name save title subheader subheaderright subheader2 subheaderright2 rollname roll rolladv emote deathsave targetAC weapon attack attackadv damage critdamage spell spellconcentration spellritual spellshowinfoblock spellshowdesc spelldescription spellshowhigherlvl spellhigherlevel spellshowattack spellattack spellshowattackadv spellattackadv spellshowsavethrow spellsavedc spellsavestat spellsavesuccess spellshowhealing spellhealing spellshowdamage spelldamage spellcancrit spellcritdamage spellshoweffects spelleffect spellpromptcastlvl spellcastlvl spellcasttime spellduration spelltarget spellrange spellgainedfrom spellcomponents ability}}
       {{/showclassactions}}
 
       <!--Outputall-->

--- a/D&D_5e_Shaped/precompiled/pages/roll_template.html
+++ b/D&D_5e_Shaped/precompiled/pages/roll_template.html
@@ -217,6 +217,12 @@
           <div class="sheet-col-15-24 sheet-pad-r-sm sheet-rt-value">{{spellcastlvl}}</div>
         </div>
       {{/spellcastlvl}}
+      {{#spellcastritual}}
+        <div class="sheet-row">
+          <div class="sheet-col-9-24 sheet-pad-l-md sheet-pad-r-md sheet-rt-key">Ritual Cast</div>
+          <div class="sheet-col-15-24 sheet-pad-r-sm sheet-rt-value">{{spellcastritual}}</div>
+        </div>
+      {{/spellcastritual}}
       {{#spellsavesuccess}}
         <div class="sheet-row">
           <div class="sheet-col-9-24 sheet-pad-l-md sheet-pad-r-md sheet-rt-key">Save success</div>
@@ -323,12 +329,12 @@
 
       <!-- Class action additions -->
       {{#showclassactions}}
-        {{#allprops() showclassactions character_name save title subheader subheaderright subheader2 subheaderright2 rollname roll rolladv emote deathsave targetAC weapon attack attackadv damage critdamage spell spellconcentration spellritual spellshowinfoblock spellshowdesc spelldescription spellshowhigherlvl spellhigherlevel spellshowattack spellattack spellshowattackadv spellattackadv spellshowsavethrow spellsavedc spellsavestat spellsavesuccess spellshowhealing spellhealing spellshowdamage spelldamage spellcancrit spellcritdamage spellshoweffects spelleffect spellpromptcastlvl spellcastlvl spellcasttime spellduration spelltarget spellrange spellgainedfrom spellcomponents ability}}
+        {{#allprops() showclassactions character_name save title subheader subheaderright subheader2 subheaderright2 rollname roll rolladv emote deathsave targetAC weapon attack attackadv damage critdamage spell spellconcentration spellritual spellshowinfoblock spellshowdesc spelldescription spellshowhigherlvl spellhigherlevel spellshowattack spellattack spellshowattackadv spellattackadv spellshowsavethrow spellsavedc spellsavestat spellsavesuccess spellshowhealing spellhealing spellshowdamage spelldamage spellcancrit spellcritdamage spellshoweffects spelleffect spellpromptcastlvl spellcastlvl spellpromptritual spellcastritual spellcasttime spellduration spelltarget spellrange spellgainedfrom spellcomponents ability}}
           <div class="sheet-row">
             <div class="sheet-col-9-24 sheet-pad-l-md sheet-pad-r-md sheet-rt-key">{{key}}</div>
             <div class="sheet-col-15-24 sheet-pad-r-sm sheet-rt-value">{{value}}</div>
           </div>
-        {{/allprops() showclassactions character_name save title subheader subheaderright subheader2 subheaderright2 rollname roll rolladv emote deathsave targetAC weapon attack attackadv damage critdamage spell spellconcentration spellritual spellshowinfoblock spellshowdesc spelldescription spellshowhigherlvl spellhigherlevel spellshowattack spellattack spellshowattackadv spellattackadv spellshowsavethrow spellsavedc spellsavestat spellsavesuccess spellshowhealing spellhealing spellshowdamage spelldamage spellcancrit spellcritdamage spellshoweffects spelleffect spellpromptcastlvl spellcastlvl spellcasttime spellduration spelltarget spellrange spellgainedfrom spellcomponents ability}}
+        {{/allprops() showclassactions character_name save title subheader subheaderright subheader2 subheaderright2 rollname roll rolladv emote deathsave targetAC weapon attack attackadv damage critdamage spell spellconcentration spellritual spellshowinfoblock spellshowdesc spelldescription spellshowhigherlvl spellhigherlevel spellshowattack spellattack spellshowattackadv spellattackadv spellshowsavethrow spellsavedc spellsavestat spellsavesuccess spellshowhealing spellhealing spellshowdamage spelldamage spellcancrit spellcritdamage spellshoweffects spelleffect spellpromptcastlvl spellcastlvl spellpromptritual spellcastritual spellcasttime spellduration spelltarget spellrange spellgainedfrom spellcomponents ability}}
       {{/showclassactions}}
 
       <!--Outputall-->

--- a/D&D_5e_Shaped/precompiled/pages/spellbook.html
+++ b/D&D_5e_Shaped/precompiled/pages/spellbook.html
@@ -692,7 +692,7 @@
                 <span class="sheet-german">Beschreibung</span>
               </div>
             </div>
-            <div class="sheet-col-1-8 sheet-center">
+            <div class="sheet-col-1-10 sheet-center">
               <input type="checkbox" name="attr_spellshowhigherlvl" value="{{spellshowhigherlvl=1}} {{spellhigherlevel=@{spellhighersloteffect}}}">
               <div class="sheet-small-label">
                 <span class="sheet-english">At higher levels</span>
@@ -707,7 +707,7 @@
                 <span class="sheet-german">Angriffswurf</span>
               </div>
             </div>
-            <div class="sheet-col-1-8 sheet-center">
+            <div class="sheet-col-1-10 sheet-center">
               <input type="checkbox" name="attr_spellshowsavethrow" value="{{spellshowsavethrow=1}} {{spellsavedc=[[@{spellsavedc} + @{customsavedc}]]}} {{spellsavestat=@{savestat}}} {{spellsavesuccess=@{savesuccess}}}">
               <div class="sheet-small-label">
                 <span class="sheet-english">Saving throw</span>
@@ -1199,7 +1199,7 @@
                 <span class="sheet-german">Beschreibung</span>
               </div>
             </div>
-            <div class="sheet-col-1-8 sheet-center">
+            <div class="sheet-col-1-10 sheet-center">
               <input type="checkbox" name="attr_spellshowhigherlvl" value="{{spellshowhigherlvl=1}} {{spellhigherlevel=@{spellhighersloteffect}}}">
               <div class="sheet-small-label">
                 <span class="sheet-english">At higher levels</span>
@@ -1214,7 +1214,7 @@
                 <span class="sheet-german">Angriffswurf</span>
               </div>
             </div>
-            <div class="sheet-col-1-8 sheet-center">
+            <div class="sheet-col-1-10 sheet-center">
               <input type="checkbox" name="attr_spellshowsavethrow" value="{{spellshowsavethrow=1}} {{spellsavedc=[[@{spellsavedc} + @{customsavedc}]]}} {{spellsavestat=@{savestat}}} {{spellsavesuccess=@{savesuccess}}}">
               <div class="sheet-small-label">
                 <span class="sheet-english">Saving throw</span>
@@ -1712,7 +1712,7 @@
                 <span class="sheet-german">Beschreibung</span>
               </div>
             </div>
-            <div class="sheet-col-1-8 sheet-center">
+            <div class="sheet-col-1-10 sheet-center">
               <input type="checkbox" name="attr_spellshowhigherlvl" value="{{spellshowhigherlvl=1}} {{spellhigherlevel=@{spellhighersloteffect}}}">
               <div class="sheet-small-label">
                 <span class="sheet-english">At higher levels</span>
@@ -1727,7 +1727,7 @@
                 <span class="sheet-german">Angriffswurf</span>
               </div>
             </div>
-            <div class="sheet-col-1-8 sheet-center">
+            <div class="sheet-col-1-10 sheet-center">
               <input type="checkbox" name="attr_spellshowsavethrow" value="{{spellshowsavethrow=1}} {{spellsavedc=[[@{spellsavedc} + @{customsavedc}]]}} {{spellsavestat=@{savestat}}} {{spellsavesuccess=@{savesuccess}}}">
               <div class="sheet-small-label">
                 <span class="sheet-english">Saving throw</span>
@@ -2225,7 +2225,7 @@
                 <span class="sheet-german">Beschreibung</span>
               </div>
             </div>
-            <div class="sheet-col-1-8 sheet-center">
+            <div class="sheet-col-1-10 sheet-center">
               <input type="checkbox" name="attr_spellshowhigherlvl" value="{{spellshowhigherlvl=1}} {{spellhigherlevel=@{spellhighersloteffect}}}">
               <div class="sheet-small-label">
                 <span class="sheet-english">At higher levels</span>
@@ -2240,7 +2240,7 @@
                 <span class="sheet-german">Angriffswurf</span>
               </div>
             </div>
-            <div class="sheet-col-1-8 sheet-center">
+            <div class="sheet-col-1-10 sheet-center">
               <input type="checkbox" name="attr_spellshowsavethrow" value="{{spellshowsavethrow=1}} {{spellsavedc=[[@{spellsavedc} + @{customsavedc}]]}} {{spellsavestat=@{savestat}}} {{spellsavesuccess=@{savesuccess}}}">
               <div class="sheet-small-label">
                 <span class="sheet-english">Saving throw</span>
@@ -2738,7 +2738,7 @@
                 <span class="sheet-german">Beschreibung</span>
               </div>
             </div>
-            <div class="sheet-col-1-8 sheet-center">
+            <div class="sheet-col-1-10 sheet-center">
               <input type="checkbox" name="attr_spellshowhigherlvl" value="{{spellshowhigherlvl=1}} {{spellhigherlevel=@{spellhighersloteffect}}}">
               <div class="sheet-small-label">
                 <span class="sheet-english">At higher levels</span>
@@ -2753,7 +2753,7 @@
                 <span class="sheet-german">Angriffswurf</span>
               </div>
             </div>
-            <div class="sheet-col-1-8 sheet-center">
+            <div class="sheet-col-1-10 sheet-center">
               <input type="checkbox" name="attr_spellshowsavethrow" value="{{spellshowsavethrow=1}} {{spellsavedc=[[@{spellsavedc} + @{customsavedc}]]}} {{spellsavestat=@{savestat}}} {{spellsavesuccess=@{savesuccess}}}">
               <div class="sheet-small-label">
                 <span class="sheet-english">Saving throw</span>
@@ -3251,7 +3251,7 @@
                 <span class="sheet-german">Beschreibung</span>
               </div>
             </div>
-            <div class="sheet-col-1-8 sheet-center">
+            <div class="sheet-col-1-10 sheet-center">
               <input type="checkbox" name="attr_spellshowhigherlvl" value="{{spellshowhigherlvl=1}} {{spellhigherlevel=@{spellhighersloteffect}}}">
               <div class="sheet-small-label">
                 <span class="sheet-english">At higher levels</span>
@@ -3266,7 +3266,7 @@
                 <span class="sheet-german">Angriffswurf</span>
               </div>
             </div>
-            <div class="sheet-col-1-8 sheet-center">
+            <div class="sheet-col-1-10 sheet-center">
               <input type="checkbox" name="attr_spellshowsavethrow" value="{{spellshowsavethrow=1}} {{spellsavedc=[[@{spellsavedc} + @{customsavedc}]]}} {{spellsavestat=@{savestat}}} {{spellsavesuccess=@{savesuccess}}}">
               <div class="sheet-small-label">
                 <span class="sheet-english">Saving throw</span>
@@ -3764,7 +3764,7 @@
                 <span class="sheet-german">Beschreibung</span>
               </div>
             </div>
-            <div class="sheet-col-1-8 sheet-center">
+            <div class="sheet-col-1-10 sheet-center">
               <input type="checkbox" name="attr_spellshowhigherlvl" value="{{spellshowhigherlvl=1}} {{spellhigherlevel=@{spellhighersloteffect}}}">
               <div class="sheet-small-label">
                 <span class="sheet-english">At higher levels</span>
@@ -3779,7 +3779,7 @@
                 <span class="sheet-german">Angriffswurf</span>
               </div>
             </div>
-            <div class="sheet-col-1-8 sheet-center">
+            <div class="sheet-col-1-10 sheet-center">
               <input type="checkbox" name="attr_spellshowsavethrow" value="{{spellshowsavethrow=1}} {{spellsavedc=[[@{spellsavedc} + @{customsavedc}]]}} {{spellsavestat=@{savestat}}} {{spellsavesuccess=@{savesuccess}}}">
               <div class="sheet-small-label">
                 <span class="sheet-english">Saving throw</span>
@@ -4277,7 +4277,7 @@
                 <span class="sheet-german">Beschreibung</span>
               </div>
             </div>
-            <div class="sheet-col-1-8 sheet-center">
+            <div class="sheet-col-1-10 sheet-center">
               <input type="checkbox" name="attr_spellshowhigherlvl" value="{{spellshowhigherlvl=1}} {{spellhigherlevel=@{spellhighersloteffect}}}">
               <div class="sheet-small-label">
                 <span class="sheet-english">At higher levels</span>
@@ -4292,7 +4292,7 @@
                 <span class="sheet-german">Angriffswurf</span>
               </div>
             </div>
-            <div class="sheet-col-1-8 sheet-center">
+            <div class="sheet-col-1-10 sheet-center">
               <input type="checkbox" name="attr_spellshowsavethrow" value="{{spellshowsavethrow=1}} {{spellsavedc=[[@{spellsavedc} + @{customsavedc}]]}} {{spellsavestat=@{savestat}}} {{spellsavesuccess=@{savesuccess}}}">
               <div class="sheet-small-label">
                 <span class="sheet-english">Saving throw</span>
@@ -4790,7 +4790,7 @@
                 <span class="sheet-german">Beschreibung</span>
               </div>
             </div>
-            <div class="sheet-col-1-8 sheet-center">
+            <div class="sheet-col-1-10 sheet-center">
               <input type="checkbox" name="attr_spellshowhigherlvl" value="{{spellshowhigherlvl=1}} {{spellhigherlevel=@{spellhighersloteffect}}}">
               <div class="sheet-small-label">
                 <span class="sheet-english">At higher levels</span>
@@ -4805,7 +4805,7 @@
                 <span class="sheet-german">Angriffswurf</span>
               </div>
             </div>
-            <div class="sheet-col-1-8 sheet-center">
+            <div class="sheet-col-1-10 sheet-center">
               <input type="checkbox" name="attr_spellshowsavethrow" value="{{spellshowsavethrow=1}} {{spellsavedc=[[@{spellsavedc} + @{customsavedc}]]}} {{spellsavestat=@{savestat}}} {{spellsavesuccess=@{savesuccess}}}">
               <div class="sheet-small-label">
                 <span class="sheet-english">Saving throw</span>
@@ -5303,7 +5303,7 @@
                 <span class="sheet-german">Beschreibung</span>
               </div>
             </div>
-            <div class="sheet-col-1-8 sheet-center">
+            <div class="sheet-col-1-10 sheet-center">
               <input type="checkbox" name="attr_spellshowhigherlvl" value="{{spellshowhigherlvl=1}} {{spellhigherlevel=@{spellhighersloteffect}}}">
               <div class="sheet-small-label">
                 <span class="sheet-english">At higher levels</span>
@@ -5318,7 +5318,7 @@
                 <span class="sheet-german">Angriffswurf</span>
               </div>
             </div>
-            <div class="sheet-col-1-8 sheet-center">
+            <div class="sheet-col-1-10 sheet-center">
               <input type="checkbox" name="attr_spellshowsavethrow" value="{{spellshowsavethrow=1}} {{spellsavedc=[[@{spellsavedc} + @{customsavedc}]]}} {{spellsavestat=@{savestat}}} {{spellsavesuccess=@{savesuccess}}}">
               <div class="sheet-small-label">
                 <span class="sheet-english">Saving throw</span>

--- a/D&D_5e_Shaped/precompiled/pages/spellbook.html
+++ b/D&D_5e_Shaped/precompiled/pages/spellbook.html
@@ -1248,8 +1248,14 @@
                 <span class="sheet-english">Cast Level Prompt</span>
               </div>
             </div>
+            <div class="sheet-col-1-12 sheet-center">
+              <input type="checkbox" name="attr_spellpromptritual" value="{{spellpromptritual=1}} {{spellcastritual=?{Would you like to cast @{spellname} as a ritual? (y/n)|n}}}">
+              <div class="sheet-small-label">
+                <span class="sheet-english">Ritual Prompt</span>
+              </div>
+            </div>
 
-            <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl}">
+            <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl} @{spellpromptritual}">
           </div>
 
           <span class="sheet-spacer"></span>
@@ -1761,8 +1767,14 @@
                 <span class="sheet-english">Cast Level Prompt</span>
               </div>
             </div>
+            <div class="sheet-col-1-12 sheet-center">
+              <input type="checkbox" name="attr_spellpromptritual" value="{{spellpromptritual=1}} {{spellcastritual=?{Would you like to cast @{spellname} as a ritual? (y/n)|n}}}">
+              <div class="sheet-small-label">
+                <span class="sheet-english">Ritual Prompt</span>
+              </div>
+            </div>
 
-            <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl}">
+            <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl} @{spellpromptritual}">
           </div>
 
           <span class="sheet-spacer"></span>
@@ -2274,8 +2286,14 @@
                 <span class="sheet-english">Cast Level Prompt</span>
               </div>
             </div>
+            <div class="sheet-col-1-12 sheet-center">
+              <input type="checkbox" name="attr_spellpromptritual" value="{{spellpromptritual=1}} {{spellcastritual=?{Would you like to cast @{spellname} as a ritual? (y/n)|n}}}">
+              <div class="sheet-small-label">
+                <span class="sheet-english">Ritual Prompt</span>
+              </div>
+            </div>
 
-            <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl}">
+            <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl} @{spellpromptritual}">
           </div>
 
           <span class="sheet-spacer"></span>
@@ -2787,8 +2805,14 @@
                 <span class="sheet-english">Cast Level Prompt</span>
               </div>
             </div>
+            <div class="sheet-col-1-12 sheet-center">
+              <input type="checkbox" name="attr_spellpromptritual" value="{{spellpromptritual=1}} {{spellcastritual=?{Would you like to cast @{spellname} as a ritual? (y/n)|n}}}">
+              <div class="sheet-small-label">
+                <span class="sheet-english">Ritual Prompt</span>
+              </div>
+            </div>
 
-            <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl}">
+            <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl} @{spellpromptritual}">
           </div>
 
           <span class="sheet-spacer"></span>
@@ -3300,8 +3324,14 @@
                 <span class="sheet-english">Cast Level Prompt</span>
               </div>
             </div>
+            <div class="sheet-col-1-12 sheet-center">
+              <input type="checkbox" name="attr_spellpromptritual" value="{{spellpromptritual=1}} {{spellcastritual=?{Would you like to cast @{spellname} as a ritual? (y/n)|n}}}">
+              <div class="sheet-small-label">
+                <span class="sheet-english">Ritual Prompt</span>
+              </div>
+            </div>
 
-            <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl}">
+            <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl} @{spellpromptritual}">
           </div>
 
           <span class="sheet-spacer"></span>
@@ -3813,8 +3843,14 @@
                 <span class="sheet-english">Cast Level Prompt</span>
               </div>
             </div>
+            <div class="sheet-col-1-12 sheet-center">
+              <input type="checkbox" name="attr_spellpromptritual" value="{{spellpromptritual=1}} {{spellcastritual=?{Would you like to cast @{spellname} as a ritual? (y/n)|n}}}">
+              <div class="sheet-small-label">
+                <span class="sheet-english">Ritual Prompt</span>
+              </div>
+            </div>
 
-            <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl}">
+            <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl} @{spellpromptritual}">
           </div>
 
           <span class="sheet-spacer"></span>
@@ -4326,8 +4362,14 @@
                 <span class="sheet-english">Cast Level Prompt</span>
               </div>
             </div>
+            <div class="sheet-col-1-12 sheet-center">
+              <input type="checkbox" name="attr_spellpromptritual" value="{{spellpromptritual=1}} {{spellcastritual=?{Would you like to cast @{spellname} as a ritual? (y/n)|n}}}">
+              <div class="sheet-small-label">
+                <span class="sheet-english">Ritual Prompt</span>
+              </div>
+            </div>
 
-            <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl}">
+            <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl} @{spellpromptritual}">
           </div>
 
           <span class="sheet-spacer"></span>
@@ -4839,8 +4881,14 @@
                 <span class="sheet-english">Cast Level Prompt</span>
               </div>
             </div>
+            <div class="sheet-col-1-12 sheet-center">
+              <input type="checkbox" name="attr_spellpromptritual" value="{{spellpromptritual=1}} {{spellcastritual=?{Would you like to cast @{spellname} as a ritual? (y/n)|n}}}">
+              <div class="sheet-small-label">
+                <span class="sheet-english">Ritual Prompt</span>
+              </div>
+            </div>
 
-            <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl}">
+            <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl} @{spellpromptritual}">
           </div>
 
           <span class="sheet-spacer"></span>
@@ -5352,8 +5400,14 @@
                 <span class="sheet-english">Cast Level Prompt</span>
               </div>
             </div>
+            <div class="sheet-col-1-12 sheet-center">
+              <input type="checkbox" name="attr_spellpromptritual" value="{{spellpromptritual=1}} {{spellcastritual=?{Would you like to cast @{spellname} as a ritual? (y/n)|n}}}">
+              <div class="sheet-small-label">
+                <span class="sheet-english">Ritual Prompt</span>
+              </div>
+            </div>
 
-            <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl}">
+            <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl} @{spellpromptritual}">
           </div>
 
           <span class="sheet-spacer"></span>

--- a/D&D_5e_Shaped/precompiled/pages/spellbook.html
+++ b/D&D_5e_Shaped/precompiled/pages/spellbook.html
@@ -1242,8 +1242,14 @@
                 <span class="sheet-german">Effekte</span>
               </div>
             </div>
+            <div class="sheet-col-1-12 sheet-center">
+              <input type="checkbox" name="attr_spellpromptcastlvl" value="{{spellpromptcastlvl=1}} {{spellcastlvl=?{Would you like to cast @{spellname} at a different level?|@{spellbaselevel}}}}">
+              <div class="sheet-small-label">
+                <span class="sheet-english">Cast Level Prompt</span>
+              </div>
+            </div>
 
-            <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects}">
+            <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl}">
           </div>
 
           <span class="sheet-spacer"></span>
@@ -1749,8 +1755,14 @@
                 <span class="sheet-german">Effekte</span>
               </div>
             </div>
+            <div class="sheet-col-1-12 sheet-center">
+              <input type="checkbox" name="attr_spellpromptcastlvl" value="{{spellpromptcastlvl=1}} {{spellcastlvl=?{Would you like to cast @{spellname} at a different level?|@{spellbaselevel}}}}">
+              <div class="sheet-small-label">
+                <span class="sheet-english">Cast Level Prompt</span>
+              </div>
+            </div>
 
-            <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects}">
+            <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl}">
           </div>
 
           <span class="sheet-spacer"></span>
@@ -2256,8 +2268,14 @@
                 <span class="sheet-german">Effekte</span>
               </div>
             </div>
+            <div class="sheet-col-1-12 sheet-center">
+              <input type="checkbox" name="attr_spellpromptcastlvl" value="{{spellpromptcastlvl=1}} {{spellcastlvl=?{Would you like to cast @{spellname} at a different level?|@{spellbaselevel}}}}">
+              <div class="sheet-small-label">
+                <span class="sheet-english">Cast Level Prompt</span>
+              </div>
+            </div>
 
-            <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects}">
+            <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl}">
           </div>
 
           <span class="sheet-spacer"></span>
@@ -2763,8 +2781,14 @@
                 <span class="sheet-german">Effekte</span>
               </div>
             </div>
+            <div class="sheet-col-1-12 sheet-center">
+              <input type="checkbox" name="attr_spellpromptcastlvl" value="{{spellpromptcastlvl=1}} {{spellcastlvl=?{Would you like to cast @{spellname} at a different level?|@{spellbaselevel}}}}">
+              <div class="sheet-small-label">
+                <span class="sheet-english">Cast Level Prompt</span>
+              </div>
+            </div>
 
-            <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects}">
+            <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl}">
           </div>
 
           <span class="sheet-spacer"></span>
@@ -3270,8 +3294,14 @@
                 <span class="sheet-german">Effekte</span>
               </div>
             </div>
+            <div class="sheet-col-1-12 sheet-center">
+              <input type="checkbox" name="attr_spellpromptcastlvl" value="{{spellpromptcastlvl=1}} {{spellcastlvl=?{Would you like to cast @{spellname} at a different level?|@{spellbaselevel}}}}">
+              <div class="sheet-small-label">
+                <span class="sheet-english">Cast Level Prompt</span>
+              </div>
+            </div>
 
-            <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects}">
+            <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl}">
           </div>
 
           <span class="sheet-spacer"></span>
@@ -3777,8 +3807,14 @@
                 <span class="sheet-german">Effekte</span>
               </div>
             </div>
+            <div class="sheet-col-1-12 sheet-center">
+              <input type="checkbox" name="attr_spellpromptcastlvl" value="{{spellpromptcastlvl=1}} {{spellcastlvl=?{Would you like to cast @{spellname} at a different level?|@{spellbaselevel}}}}">
+              <div class="sheet-small-label">
+                <span class="sheet-english">Cast Level Prompt</span>
+              </div>
+            </div>
 
-            <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects}">
+            <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl}">
           </div>
 
           <span class="sheet-spacer"></span>
@@ -4284,8 +4320,14 @@
                 <span class="sheet-german">Effekte</span>
               </div>
             </div>
+            <div class="sheet-col-1-12 sheet-center">
+              <input type="checkbox" name="attr_spellpromptcastlvl" value="{{spellpromptcastlvl=1}} {{spellcastlvl=?{Would you like to cast @{spellname} at a different level?|@{spellbaselevel}}}}">
+              <div class="sheet-small-label">
+                <span class="sheet-english">Cast Level Prompt</span>
+              </div>
+            </div>
 
-            <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects}">
+            <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl}">
           </div>
 
           <span class="sheet-spacer"></span>
@@ -4791,8 +4833,14 @@
                 <span class="sheet-german">Effekte</span>
               </div>
             </div>
+            <div class="sheet-col-1-12 sheet-center">
+              <input type="checkbox" name="attr_spellpromptcastlvl" value="{{spellpromptcastlvl=1}} {{spellcastlvl=?{Would you like to cast @{spellname} at a different level?|@{spellbaselevel}}}}">
+              <div class="sheet-small-label">
+                <span class="sheet-english">Cast Level Prompt</span>
+              </div>
+            </div>
 
-            <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects}">
+            <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl}">
           </div>
 
           <span class="sheet-spacer"></span>
@@ -5298,8 +5346,14 @@
                 <span class="sheet-german">Effekte</span>
               </div>
             </div>
+            <div class="sheet-col-1-12 sheet-center">
+              <input type="checkbox" name="attr_spellpromptcastlvl" value="{{spellpromptcastlvl=1}} {{spellcastlvl=?{Would you like to cast @{spellname} at a different level?|@{spellbaselevel}}}}">
+              <div class="sheet-small-label">
+                <span class="sheet-english">Cast Level Prompt</span>
+              </div>
+            </div>
 
-            <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects}">
+            <input type="hidden" name="attr_spellcastmacrooptions" value="@{spellshowinfoblock} @{spellshowdesc} @{spellshowhigherlvl} @{spellshowattack} @{spellshowattackadv} @{spellshowsavethrow} @{spellshowhealing} @{spellshowdamage} @{spellshoweffects} @{spellpromptcastlvl}">
           </div>
 
           <span class="sheet-spacer"></span>


### PR DESCRIPTION
​​I have added 2 checkboxes on the spell macro options which, if checked, will prompt the caster what level to cast a spell at and if the spell is being cast a ritual. This output is then included in the roll template. The checkboxes are not presented on the cantrip page.
​
​My motivation for adding this is I have an API script which watches for spell casts from the sheet, and then decrements the appropriate spell slot (or informs a caster that they lack spell slots). Right now I have the prompt embedded in the spell description, which is less than elegant.

![image](https://cloud.githubusercontent.com/assets/218431/7580091/be31a274-f81a-11e4-8693-860f0a36cb82.png)

![image](https://cloud.githubusercontent.com/assets/218431/7580096/cd15c6d0-f81a-11e4-9cb4-ae9a14931ca7.png)

![image](https://cloud.githubusercontent.com/assets/218431/7580098/d805fed4-f81a-11e4-89f8-de216d9a6f6b.png)

![image](https://cloud.githubusercontent.com/assets/218431/7580124/26bafa48-f81b-11e4-9922-e7d4af58e82d.png)
