### PR TITLE
A couple visual tweaks to the spellbook

### DIFF
--- a/D&D_5e_Shaped/D&D_5e.css
+++ b/D&D_5e_Shaped/D&D_5e.css
@@ -1219,7 +1219,7 @@ div[class^="sheet-classaction-row"] {
 }
 .sheet-section-spellbook .sheet-wrap-box textarea,
 .sheet-section-actions .sheet-wrap-box textarea {
-  font-size: 80%;
+  font-size: 100%;
   line-height: 100%;
   resize: vertical;
 }

--- a/D&D_5e_Shaped/D&D_5e.css
+++ b/D&D_5e_Shaped/D&D_5e.css
@@ -1221,6 +1221,7 @@ div[class^="sheet-classaction-row"] {
 .sheet-section-actions .sheet-wrap-box textarea {
   font-size: 80%;
   line-height: 100%;
+  resize: vertical;
 }
 
 .sheet-section-actions div[class*="sheet-toggle-"],


### PR DESCRIPTION
The font-size on the spell text areas was rather hard to read when set to 80% of 12px. This is of course a subjective opinion; feel free to ignore if you disagree.

I've also made the textareas in the spellbook resizable by users. Some of the spell descriptions can be rather lengthy, so it is really handy to be able to resize them at will.
