### PR TITLE
Remove redundant classactionname.

### DIFF
--- a/D&D_5e_Shaped/D&D_5e.html
+++ b/D&D_5e_Shaped/D&D_5e.html
@@ -3135,7 +3135,7 @@
             </select>
           </div>
           <div class="sheet-col-1-6 sheet-center">
-            <button type="roll" class="sheet-roll" name="roll_classaction1" value="@{output_option} &{template:5eDefault} {{classaction=1}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname1}}} {{subheader=Class Action 1}} {{freetextname=@{classactionname1}}} {{freetext=@{classactionoutput1}}}">
+            <button type="roll" class="sheet-roll" name="roll_classaction1" value="@{output_option} &{template:5eDefault} {{classaction=1}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname1}}} {{subheader=Class Action 1}} {{freetext=@{classactionoutput1}}}">
               <span>Use</span>
             </button>
           </div>
@@ -3384,7 +3384,7 @@
             </select>
           </div>
           <div class="sheet-col-1-6 sheet-center">
-            <button type="roll" class="sheet-roll" name="roll_classaction2" value="@{output_option} &{template:5eDefault} {{classaction=2}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname2}}} {{subheader=Class Action 2}} {{freetextname=@{classactionname2}}} {{freetext=@{classactionoutput2}}}">
+            <button type="roll" class="sheet-roll" name="roll_classaction2" value="@{output_option} &{template:5eDefault} {{classaction=2}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname2}}} {{subheader=Class Action 2}} {{freetext=@{classactionoutput2}}}">
               <span>Use</span>
             </button>
           </div>
@@ -3633,7 +3633,7 @@
             </select>
           </div>
           <div class="sheet-col-1-6 sheet-center">
-            <button type="roll" class="sheet-roll" name="roll_classaction3" value="@{output_option} &{template:5eDefault} {{classaction=3}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname3}}} {{subheader=Class Action 3}} {{freetextname=@{classactionname3}}} {{freetext=@{classactionoutput3}}}">
+            <button type="roll" class="sheet-roll" name="roll_classaction3" value="@{output_option} &{template:5eDefault} {{classaction=3}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname3}}} {{subheader=Class Action 3}} {{freetext=@{classactionoutput3}}}">
               <span>Use</span>
             </button>
           </div>
@@ -3882,7 +3882,7 @@
             </select>
           </div>
           <div class="sheet-col-1-6 sheet-center">
-            <button type="roll" class="sheet-roll" name="roll_classaction4" value="@{output_option} &{template:5eDefault} {{classaction=4}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname4}}} {{subheader=Class Action 4}} {{freetextname=@{classactionname4}}} {{freetext=@{classactionoutput4}}}">
+            <button type="roll" class="sheet-roll" name="roll_classaction4" value="@{output_option} &{template:5eDefault} {{classaction=4}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname4}}} {{subheader=Class Action 4}} {{freetext=@{classactionoutput4}}}">
               <span>Use</span>
             </button>
           </div>
@@ -4131,7 +4131,7 @@
             </select>
           </div>
           <div class="sheet-col-1-6 sheet-center">
-            <button type="roll" class="sheet-roll" name="roll_classaction5" value="@{output_option} &{template:5eDefault} {{classaction=5}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname5}}} {{subheader=Class Action 5}} {{freetextname=@{classactionname5}}} {{freetext=@{classactionoutput5}}}">
+            <button type="roll" class="sheet-roll" name="roll_classaction5" value="@{output_option} &{template:5eDefault} {{classaction=5}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname5}}} {{subheader=Class Action 5}} {{freetext=@{classactionoutput5}}}">
               <span>Use</span>
             </button>
           </div>
@@ -4382,7 +4382,7 @@
             </select>
           </div>
           <div class="sheet-col-1-6 sheet-center">
-            <button type="roll" class="sheet-roll" name="roll_classaction6" value="@{output_option} &{template:5eDefault} {{classaction=6}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname6}}} {{subheader=Class Action 6}} {{freetextname=@{classactionname6}}} {{freetext=@{classactionoutput6}}}">
+            <button type="roll" class="sheet-roll" name="roll_classaction6" value="@{output_option} &{template:5eDefault} {{classaction=6}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname6}}} {{subheader=Class Action 6}} {{freetext=@{classactionoutput6}}}">
               <span>Use</span>
             </button>
           </div>
@@ -4631,7 +4631,7 @@
             </select>
           </div>
           <div class="sheet-col-1-6 sheet-center">
-            <button type="roll" class="sheet-roll" name="roll_classaction7" value="@{output_option} &{template:5eDefault} {{classaction=7}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname7}}} {{subheader=Class Action 7}} {{freetextname=@{classactionname7}}} {{freetext=@{classactionoutput7}}}">
+            <button type="roll" class="sheet-roll" name="roll_classaction7" value="@{output_option} &{template:5eDefault} {{classaction=7}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname7}}} {{subheader=Class Action 7}} {{freetext=@{classactionoutput7}}}">
               <span>Use</span>
             </button>
           </div>
@@ -4880,7 +4880,7 @@
             </select>
           </div>
           <div class="sheet-col-1-6 sheet-center">
-            <button type="roll" class="sheet-roll" name="roll_classaction8" value="@{output_option} &{template:5eDefault} {{classaction=8}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname8}}} {{subheader=Class Action 8}} {{freetextname=@{classactionname8}}} {{freetext=@{classactionoutput8}}}">
+            <button type="roll" class="sheet-roll" name="roll_classaction8" value="@{output_option} &{template:5eDefault} {{classaction=8}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname8}}} {{subheader=Class Action 8}} {{freetext=@{classactionoutput8}}}">
               <span>Use</span>
             </button>
           </div>
@@ -5129,7 +5129,7 @@
             </select>
           </div>
           <div class="sheet-col-1-6 sheet-center">
-            <button type="roll" class="sheet-roll" name="roll_classaction9" value="@{output_option} &{template:5eDefault} {{classaction=9}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname9}}} {{subheader=Class Action 9}} {{freetextname=@{classactionname9}}} {{freetext=@{classactionoutput9}}}">
+            <button type="roll" class="sheet-roll" name="roll_classaction9" value="@{output_option} &{template:5eDefault} {{classaction=9}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname9}}} {{subheader=Class Action 9}} {{freetext=@{classactionoutput9}}}">
               <span>Use</span>
             </button>
           </div>
@@ -5378,7 +5378,7 @@
             </select>
           </div>
           <div class="sheet-col-1-6 sheet-center">
-            <button type="roll" class="sheet-roll" name="roll_classaction10" value="@{output_option} &{template:5eDefault} {{classaction=10}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname10}}} {{subheader=Class Action 10}} {{freetextname=@{classactionname10}}} {{freetext=@{classactionoutput10}}}">
+            <button type="roll" class="sheet-roll" name="roll_classaction10" value="@{output_option} &{template:5eDefault} {{classaction=10}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname10}}} {{subheader=Class Action 10}} {{freetext=@{classactionoutput10}}}">
               <span>Use</span>
             </button>
           </div>
@@ -5629,7 +5629,7 @@
             </select>
           </div>
           <div class="sheet-col-1-6 sheet-center">
-            <button type="roll" class="sheet-roll" name="roll_classaction11" value="@{output_option} &{template:5eDefault} {{classaction=11}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname11}}} {{subheader=Class Action 11}} {{freetextname=@{classactionname11}}} {{freetext=@{classactionoutput11}}}">
+            <button type="roll" class="sheet-roll" name="roll_classaction11" value="@{output_option} &{template:5eDefault} {{classaction=11}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname11}}} {{subheader=Class Action 11}} {{freetext=@{classactionoutput11}}}">
               <span>Use</span>
             </button>
           </div>
@@ -5878,7 +5878,7 @@
             </select>
           </div>
           <div class="sheet-col-1-6 sheet-center">
-            <button type="roll" class="sheet-roll" name="roll_classaction12" value="@{output_option} &{template:5eDefault} {{classaction=12}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname12}}} {{subheader=Class Action 12}} {{freetextname=@{classactionname12}}} {{freetext=@{classactionoutput12}}}">
+            <button type="roll" class="sheet-roll" name="roll_classaction12" value="@{output_option} &{template:5eDefault} {{classaction=12}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname12}}} {{subheader=Class Action 12}} {{freetext=@{classactionoutput12}}}">
               <span>Use</span>
             </button>
           </div>
@@ -6127,7 +6127,7 @@
             </select>
           </div>
           <div class="sheet-col-1-6 sheet-center">
-            <button type="roll" class="sheet-roll" name="roll_classaction13" value="@{output_option} &{template:5eDefault} {{classaction=13}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname13}}} {{subheader=Class Action 13}} {{freetextname=@{classactionname13}}} {{freetext=@{classactionoutput13}}}">
+            <button type="roll" class="sheet-roll" name="roll_classaction13" value="@{output_option} &{template:5eDefault} {{classaction=13}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname13}}} {{subheader=Class Action 13}} {{freetext=@{classactionoutput13}}}">
               <span>Use</span>
             </button>
           </div>
@@ -6376,7 +6376,7 @@
             </select>
           </div>
           <div class="sheet-col-1-6 sheet-center">
-            <button type="roll" class="sheet-roll" name="roll_classaction14" value="@{output_option} &{template:5eDefault} {{classaction=14}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname14}}} {{subheader=Class Action 14}} {{freetextname=@{classactionname14}}} {{freetext=@{classactionoutput14}}}">
+            <button type="roll" class="sheet-roll" name="roll_classaction14" value="@{output_option} &{template:5eDefault} {{classaction=14}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname14}}} {{subheader=Class Action 14}} {{freetext=@{classactionoutput14}}}">
               <span>Use</span>
             </button>
           </div>
@@ -6625,7 +6625,7 @@
             </select>
           </div>
           <div class="sheet-col-1-6 sheet-center">
-            <button type="roll" class="sheet-roll" name="roll_classaction15" value="@{output_option} &{template:5eDefault} {{classaction=15}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname15}}} {{subheader=Class Action 15}} {{freetextname=@{classactionname15}}} {{freetext=@{classactionoutput15}}}">
+            <button type="roll" class="sheet-roll" name="roll_classaction15" value="@{output_option} &{template:5eDefault} {{classaction=15}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname15}}} {{subheader=Class Action 15}} {{freetext=@{classactionoutput15}}}">
               <span>Use</span>
             </button>
           </div>
@@ -6876,7 +6876,7 @@
             </select>
           </div>
           <div class="sheet-col-1-6 sheet-center">
-            <button type="roll" class="sheet-roll" name="roll_classaction16" value="@{output_option} &{template:5eDefault} {{classaction=16}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname16}}} {{subheader=Class Action 16}} {{freetextname=@{classactionname16}}} {{freetext=@{classactionoutput16}}}">
+            <button type="roll" class="sheet-roll" name="roll_classaction16" value="@{output_option} &{template:5eDefault} {{classaction=16}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname16}}} {{subheader=Class Action 16}} {{freetext=@{classactionoutput16}}}">
               <span>Use</span>
             </button>
           </div>
@@ -7125,7 +7125,7 @@
             </select>
           </div>
           <div class="sheet-col-1-6 sheet-center">
-            <button type="roll" class="sheet-roll" name="roll_classaction17" value="@{output_option} &{template:5eDefault} {{classaction=17}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname17}}} {{subheader=Class Action 17}} {{freetextname=@{classactionname17}}} {{freetext=@{classactionoutput17}}}">
+            <button type="roll" class="sheet-roll" name="roll_classaction17" value="@{output_option} &{template:5eDefault} {{classaction=17}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname17}}} {{subheader=Class Action 17}} {{freetext=@{classactionoutput17}}}">
               <span>Use</span>
             </button>
           </div>
@@ -7374,7 +7374,7 @@
             </select>
           </div>
           <div class="sheet-col-1-6 sheet-center">
-            <button type="roll" class="sheet-roll" name="roll_classaction18" value="@{output_option} &{template:5eDefault} {{classaction=18}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname18}}} {{subheader=Class Action 18}} {{freetextname=@{classactionname18}}} {{freetext=@{classactionoutput18}}}">
+            <button type="roll" class="sheet-roll" name="roll_classaction18" value="@{output_option} &{template:5eDefault} {{classaction=18}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname18}}} {{subheader=Class Action 18}} {{freetext=@{classactionoutput18}}}">
               <span>Use</span>
             </button>
           </div>
@@ -7623,7 +7623,7 @@
             </select>
           </div>
           <div class="sheet-col-1-6 sheet-center">
-            <button type="roll" class="sheet-roll" name="roll_classaction19" value="@{output_option} &{template:5eDefault} {{classaction=19}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname19}}} {{subheader=Class Action 19}} {{freetextname=@{classactionname19}}} {{freetext=@{classactionoutput19}}}">
+            <button type="roll" class="sheet-roll" name="roll_classaction19" value="@{output_option} &{template:5eDefault} {{classaction=19}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname19}}} {{subheader=Class Action 19}} {{freetext=@{classactionoutput19}}}">
               <span>Use</span>
             </button>
           </div>
@@ -7872,7 +7872,7 @@
             </select>
           </div>
           <div class="sheet-col-1-6 sheet-center">
-            <button type="roll" class="sheet-roll" name="roll_classaction20" value="@{output_option} &{template:5eDefault} {{classaction=20}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname20}}} {{subheader=Class Action 20}} {{freetextname=@{classactionname20}}} {{freetext=@{classactionoutput20}}}">
+            <button type="roll" class="sheet-roll" name="roll_classaction20" value="@{output_option} &{template:5eDefault} {{classaction=20}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname20}}} {{subheader=Class Action 20}} {{freetext=@{classactionoutput20}}}">
               <span>Use</span>
             </button>
           </div>

--- a/D&D_5e_Shaped/precompiled/pages/class.html
+++ b/D&D_5e_Shaped/precompiled/pages/class.html
@@ -306,7 +306,7 @@
           </select>
         </div>
         <div class="sheet-col-1-6 sheet-center">
-          <button type="roll" class="sheet-roll" name="roll_classaction1" value="@{output_option} &{template:5eDefault} {{classaction=1}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname1}}} {{subheader=Class Action 1}} {{freetextname=@{classactionname1}}} {{freetext=@{classactionoutput1}}}">
+          <button type="roll" class="sheet-roll" name="roll_classaction1" value="@{output_option} &{template:5eDefault} {{classaction=1}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname1}}} {{subheader=Class Action 1}} {{freetext=@{classactionoutput1}}}">
             <span>Use</span>
           </button>
         </div>
@@ -555,7 +555,7 @@
           </select>
         </div>
         <div class="sheet-col-1-6 sheet-center">
-          <button type="roll" class="sheet-roll" name="roll_classaction2" value="@{output_option} &{template:5eDefault} {{classaction=2}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname2}}} {{subheader=Class Action 2}} {{freetextname=@{classactionname2}}} {{freetext=@{classactionoutput2}}}">
+          <button type="roll" class="sheet-roll" name="roll_classaction2" value="@{output_option} &{template:5eDefault} {{classaction=2}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname2}}} {{subheader=Class Action 2}} {{freetext=@{classactionoutput2}}}">
             <span>Use</span>
           </button>
         </div>
@@ -804,7 +804,7 @@
           </select>
         </div>
         <div class="sheet-col-1-6 sheet-center">
-          <button type="roll" class="sheet-roll" name="roll_classaction3" value="@{output_option} &{template:5eDefault} {{classaction=3}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname3}}} {{subheader=Class Action 3}} {{freetextname=@{classactionname3}}} {{freetext=@{classactionoutput3}}}">
+          <button type="roll" class="sheet-roll" name="roll_classaction3" value="@{output_option} &{template:5eDefault} {{classaction=3}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname3}}} {{subheader=Class Action 3}} {{freetext=@{classactionoutput3}}}">
             <span>Use</span>
           </button>
         </div>
@@ -1053,7 +1053,7 @@
           </select>
         </div>
         <div class="sheet-col-1-6 sheet-center">
-          <button type="roll" class="sheet-roll" name="roll_classaction4" value="@{output_option} &{template:5eDefault} {{classaction=4}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname4}}} {{subheader=Class Action 4}} {{freetextname=@{classactionname4}}} {{freetext=@{classactionoutput4}}}">
+          <button type="roll" class="sheet-roll" name="roll_classaction4" value="@{output_option} &{template:5eDefault} {{classaction=4}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname4}}} {{subheader=Class Action 4}} {{freetext=@{classactionoutput4}}}">
             <span>Use</span>
           </button>
         </div>
@@ -1302,7 +1302,7 @@
           </select>
         </div>
         <div class="sheet-col-1-6 sheet-center">
-          <button type="roll" class="sheet-roll" name="roll_classaction5" value="@{output_option} &{template:5eDefault} {{classaction=5}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname5}}} {{subheader=Class Action 5}} {{freetextname=@{classactionname5}}} {{freetext=@{classactionoutput5}}}">
+          <button type="roll" class="sheet-roll" name="roll_classaction5" value="@{output_option} &{template:5eDefault} {{classaction=5}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname5}}} {{subheader=Class Action 5}} {{freetext=@{classactionoutput5}}}">
             <span>Use</span>
           </button>
         </div>
@@ -1553,7 +1553,7 @@
           </select>
         </div>
         <div class="sheet-col-1-6 sheet-center">
-          <button type="roll" class="sheet-roll" name="roll_classaction6" value="@{output_option} &{template:5eDefault} {{classaction=6}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname6}}} {{subheader=Class Action 6}} {{freetextname=@{classactionname6}}} {{freetext=@{classactionoutput6}}}">
+          <button type="roll" class="sheet-roll" name="roll_classaction6" value="@{output_option} &{template:5eDefault} {{classaction=6}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname6}}} {{subheader=Class Action 6}} {{freetext=@{classactionoutput6}}}">
             <span>Use</span>
           </button>
         </div>
@@ -1802,7 +1802,7 @@
           </select>
         </div>
         <div class="sheet-col-1-6 sheet-center">
-          <button type="roll" class="sheet-roll" name="roll_classaction7" value="@{output_option} &{template:5eDefault} {{classaction=7}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname7}}} {{subheader=Class Action 7}} {{freetextname=@{classactionname7}}} {{freetext=@{classactionoutput7}}}">
+          <button type="roll" class="sheet-roll" name="roll_classaction7" value="@{output_option} &{template:5eDefault} {{classaction=7}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname7}}} {{subheader=Class Action 7}} {{freetext=@{classactionoutput7}}}">
             <span>Use</span>
           </button>
         </div>
@@ -2051,7 +2051,7 @@
           </select>
         </div>
         <div class="sheet-col-1-6 sheet-center">
-          <button type="roll" class="sheet-roll" name="roll_classaction8" value="@{output_option} &{template:5eDefault} {{classaction=8}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname8}}} {{subheader=Class Action 8}} {{freetextname=@{classactionname8}}} {{freetext=@{classactionoutput8}}}">
+          <button type="roll" class="sheet-roll" name="roll_classaction8" value="@{output_option} &{template:5eDefault} {{classaction=8}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname8}}} {{subheader=Class Action 8}} {{freetext=@{classactionoutput8}}}">
             <span>Use</span>
           </button>
         </div>
@@ -2300,7 +2300,7 @@
           </select>
         </div>
         <div class="sheet-col-1-6 sheet-center">
-          <button type="roll" class="sheet-roll" name="roll_classaction9" value="@{output_option} &{template:5eDefault} {{classaction=9}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname9}}} {{subheader=Class Action 9}} {{freetextname=@{classactionname9}}} {{freetext=@{classactionoutput9}}}">
+          <button type="roll" class="sheet-roll" name="roll_classaction9" value="@{output_option} &{template:5eDefault} {{classaction=9}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname9}}} {{subheader=Class Action 9}} {{freetext=@{classactionoutput9}}}">
             <span>Use</span>
           </button>
         </div>
@@ -2549,7 +2549,7 @@
           </select>
         </div>
         <div class="sheet-col-1-6 sheet-center">
-          <button type="roll" class="sheet-roll" name="roll_classaction10" value="@{output_option} &{template:5eDefault} {{classaction=10}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname10}}} {{subheader=Class Action 10}} {{freetextname=@{classactionname10}}} {{freetext=@{classactionoutput10}}}">
+          <button type="roll" class="sheet-roll" name="roll_classaction10" value="@{output_option} &{template:5eDefault} {{classaction=10}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname10}}} {{subheader=Class Action 10}} {{freetext=@{classactionoutput10}}}">
             <span>Use</span>
           </button>
         </div>
@@ -2800,7 +2800,7 @@
           </select>
         </div>
         <div class="sheet-col-1-6 sheet-center">
-          <button type="roll" class="sheet-roll" name="roll_classaction11" value="@{output_option} &{template:5eDefault} {{classaction=11}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname11}}} {{subheader=Class Action 11}} {{freetextname=@{classactionname11}}} {{freetext=@{classactionoutput11}}}">
+          <button type="roll" class="sheet-roll" name="roll_classaction11" value="@{output_option} &{template:5eDefault} {{classaction=11}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname11}}} {{subheader=Class Action 11}} {{freetext=@{classactionoutput11}}}">
             <span>Use</span>
           </button>
         </div>
@@ -3049,7 +3049,7 @@
           </select>
         </div>
         <div class="sheet-col-1-6 sheet-center">
-          <button type="roll" class="sheet-roll" name="roll_classaction12" value="@{output_option} &{template:5eDefault} {{classaction=12}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname12}}} {{subheader=Class Action 12}} {{freetextname=@{classactionname12}}} {{freetext=@{classactionoutput12}}}">
+          <button type="roll" class="sheet-roll" name="roll_classaction12" value="@{output_option} &{template:5eDefault} {{classaction=12}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname12}}} {{subheader=Class Action 12}} {{freetext=@{classactionoutput12}}}">
             <span>Use</span>
           </button>
         </div>
@@ -3298,7 +3298,7 @@
           </select>
         </div>
         <div class="sheet-col-1-6 sheet-center">
-          <button type="roll" class="sheet-roll" name="roll_classaction13" value="@{output_option} &{template:5eDefault} {{classaction=13}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname13}}} {{subheader=Class Action 13}} {{freetextname=@{classactionname13}}} {{freetext=@{classactionoutput13}}}">
+          <button type="roll" class="sheet-roll" name="roll_classaction13" value="@{output_option} &{template:5eDefault} {{classaction=13}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname13}}} {{subheader=Class Action 13}} {{freetext=@{classactionoutput13}}}">
             <span>Use</span>
           </button>
         </div>
@@ -3547,7 +3547,7 @@
           </select>
         </div>
         <div class="sheet-col-1-6 sheet-center">
-          <button type="roll" class="sheet-roll" name="roll_classaction14" value="@{output_option} &{template:5eDefault} {{classaction=14}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname14}}} {{subheader=Class Action 14}} {{freetextname=@{classactionname14}}} {{freetext=@{classactionoutput14}}}">
+          <button type="roll" class="sheet-roll" name="roll_classaction14" value="@{output_option} &{template:5eDefault} {{classaction=14}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname14}}} {{subheader=Class Action 14}} {{freetext=@{classactionoutput14}}}">
             <span>Use</span>
           </button>
         </div>
@@ -3796,7 +3796,7 @@
           </select>
         </div>
         <div class="sheet-col-1-6 sheet-center">
-          <button type="roll" class="sheet-roll" name="roll_classaction15" value="@{output_option} &{template:5eDefault} {{classaction=15}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname15}}} {{subheader=Class Action 15}} {{freetextname=@{classactionname15}}} {{freetext=@{classactionoutput15}}}">
+          <button type="roll" class="sheet-roll" name="roll_classaction15" value="@{output_option} &{template:5eDefault} {{classaction=15}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname15}}} {{subheader=Class Action 15}} {{freetext=@{classactionoutput15}}}">
             <span>Use</span>
           </button>
         </div>
@@ -4047,7 +4047,7 @@
           </select>
         </div>
         <div class="sheet-col-1-6 sheet-center">
-          <button type="roll" class="sheet-roll" name="roll_classaction16" value="@{output_option} &{template:5eDefault} {{classaction=16}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname16}}} {{subheader=Class Action 16}} {{freetextname=@{classactionname16}}} {{freetext=@{classactionoutput16}}}">
+          <button type="roll" class="sheet-roll" name="roll_classaction16" value="@{output_option} &{template:5eDefault} {{classaction=16}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname16}}} {{subheader=Class Action 16}} {{freetext=@{classactionoutput16}}}">
             <span>Use</span>
           </button>
         </div>
@@ -4296,7 +4296,7 @@
           </select>
         </div>
         <div class="sheet-col-1-6 sheet-center">
-          <button type="roll" class="sheet-roll" name="roll_classaction17" value="@{output_option} &{template:5eDefault} {{classaction=17}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname17}}} {{subheader=Class Action 17}} {{freetextname=@{classactionname17}}} {{freetext=@{classactionoutput17}}}">
+          <button type="roll" class="sheet-roll" name="roll_classaction17" value="@{output_option} &{template:5eDefault} {{classaction=17}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname17}}} {{subheader=Class Action 17}} {{freetext=@{classactionoutput17}}}">
             <span>Use</span>
           </button>
         </div>
@@ -4545,7 +4545,7 @@
           </select>
         </div>
         <div class="sheet-col-1-6 sheet-center">
-          <button type="roll" class="sheet-roll" name="roll_classaction18" value="@{output_option} &{template:5eDefault} {{classaction=18}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname18}}} {{subheader=Class Action 18}} {{freetextname=@{classactionname18}}} {{freetext=@{classactionoutput18}}}">
+          <button type="roll" class="sheet-roll" name="roll_classaction18" value="@{output_option} &{template:5eDefault} {{classaction=18}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname18}}} {{subheader=Class Action 18}} {{freetext=@{classactionoutput18}}}">
             <span>Use</span>
           </button>
         </div>
@@ -4794,7 +4794,7 @@
           </select>
         </div>
         <div class="sheet-col-1-6 sheet-center">
-          <button type="roll" class="sheet-roll" name="roll_classaction19" value="@{output_option} &{template:5eDefault} {{classaction=19}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname19}}} {{subheader=Class Action 19}} {{freetextname=@{classactionname19}}} {{freetext=@{classactionoutput19}}}">
+          <button type="roll" class="sheet-roll" name="roll_classaction19" value="@{output_option} &{template:5eDefault} {{classaction=19}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname19}}} {{subheader=Class Action 19}} {{freetext=@{classactionoutput19}}}">
             <span>Use</span>
           </button>
         </div>
@@ -5043,7 +5043,7 @@
           </select>
         </div>
         <div class="sheet-col-1-6 sheet-center">
-          <button type="roll" class="sheet-roll" name="roll_classaction20" value="@{output_option} &{template:5eDefault} {{classaction=20}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname20}}} {{subheader=Class Action 20}} {{freetextname=@{classactionname20}}} {{freetext=@{classactionoutput20}}}">
+          <button type="roll" class="sheet-roll" name="roll_classaction20" value="@{output_option} &{template:5eDefault} {{classaction=20}} {{character_name=@{character_name}}} @{show_character_name} {{title=@{classactionname20}}} {{subheader=Class Action 20}} {{freetext=@{classactionoutput20}}}">
             <span>Use</span>
           </button>
         </div>


### PR DESCRIPTION
The duplication here seems unnecessary. Feel free to ignore this PR if you disagree.

Before:

![screenshot](https://cloud.githubusercontent.com/assets/218431/7668664/522c7c36-fbf1-11e4-83ce-1945a88e82c8.png)

After:

![image](https://cloud.githubusercontent.com/assets/218431/7668668/6c8abf34-fbf1-11e4-8bae-6e442399a5b9.png)

(Site note: No idea what is up with GH showing the "Warlock" option changed. My `git show` output shows no such change. If you download the branch it looks correct. I'm guessing it is more EOL weirdness triggering a bug in GitHub.)

Cheers!
