### PR TITLE
Add buttons to hide various elements of the spell page.

### DIFF
--- a/D&D_5e_Shaped/precompiled/D&D_5e.scss
+++ b/D&D_5e_Shaped/precompiled/D&D_5e.scss
@@ -1269,6 +1269,14 @@ $tab-spell-page-width: 8.6%;
 @include tab-toggle('spell-source', 35px, 'padding');
 @include tab-toggle('spell-from', 25px, 'padding');
 @include tab-toggle('recharge', 47px, 'padding');
+@include tab-toggle('display-options', 70px, 'padding');
+@include tab-toggle('spell-dashboard', 48px, 'padding');
+@include tab-toggle('spell-slots', 23px, 'padding');
+@include tab-toggle('sorcery-points', 39px, 'padding');
+@include tab-toggle('warlock-slots', 37px, 'padding');
+@include tab-toggle('spell-filters', 28px, 'padding');
+@include tab-toggle('spell-toggle-buttons', 36px, 'padding');
+@include tab-toggle('spell-unchecked-attrs', 21px, 'padding');
 
 span.sheet-toggle-spells-filter-casting-time-any,
 span.sheet-toggle-casting-time-reaction {
@@ -1641,8 +1649,26 @@ input.sheet-toggle-hd-d10:not(:checked) ~ div.sheet-toggle-hd-d10,
 input.sheet-toggle-hd-d12:not(:checked) ~ div.sheet-toggle-hd-d12,
 input.sheet-toggle-hd-d20:not(:checked) ~ div.sheet-toggle-hd-d20,
 	/* Class Action */
-input[class^="sheet-classactionshowoptions"]:not(:checked) ~ div.sheet-classaction-output-options {
+input[class^="sheet-classactionshowoptions"]:not(:checked) ~ div.sheet-classaction-output-options,
+        /* Spell display options */
+input.sheet-toggle-display-options:not(:checked) ~ .sheet-display-option,
+input.sheet-toggle-spell-dashboard:not(:checked) ~ .sheet-spell-dashboard,
+input.sheet-toggle-spell-dashboard:not(:checked) ~ .sheet-toggle-warlock-slots,
+input.sheet-toggle-spell-dashboard:not(:checked) ~ .sheet-toggle-sorcery-points,
+input.sheet-toggle-spell-dashboard:not(:checked) ~ .sheet-toggle-spell-slots,
+input.sheet-toggle-spell-slots:not(:checked) ~ div div.sheet-spell-slots-points,
+input.sheet-toggle-sorcery-points:not(:checked) ~ div div.sheet-spell-sorcery-points,
+input.sheet-toggle-warlock-slots:not(:checked) ~ div div.sheet-spell-warlock-slots,
+input.sheet-toggle-spell-toggle-buttons:not(:checked) ~ div .sheet-spell-toggle-button,
+input.sheet-toggle-spell-filters:not(:checked) ~ [class^=sheet-toggle-spells-filter],
+input.sheet-toggle-spell-filters:not(:checked) ~ span.sheet-spells-filter,
+input.sheet-toggle-spell-unchecked-attrs:not(:checked) ~ div div.sheet-wrap-box > input[class^=sheet-toggle]:not(:checked),
+input.sheet-toggle-spell-unchecked-attrs:not(:checked) ~ div div.sheet-wrap-box > input[class^=sheet-toggle]:not(:checked) + span {
 	display: none;
+}
+
+input.sheet-toggle-spell-unchecked-attrs:not(:checked) ~ div div.sheet-wrap-box > input[class^=sheet-toggle]:checked + span {
+	border-radius: $borderRadius;
 }
 
 .sheet-section-spells {

--- a/D&D_5e_Shaped/precompiled/components/spells/spell-page.html
+++ b/D&D_5e_Shaped/precompiled/components/spells/spell-page.html
@@ -196,103 +196,103 @@
         <input type="hidden" name="attr_spell_var_gained_from" value="{{spellgainedfrom=@{spellgainedfrom}}}">
         <input type="hidden" name="attr_spell_var_bonuses" value="1">
 
-        <input type="checkbox" name="attr_spell_toggle_description" class="sheet-toggle-description" value="@{spell_var_description}"><span class="sheet-toggle-description">
+        <input type="checkbox" name="attr_spell_toggle_description" class="sheet-toggle-description sheet-spell-toggle-button" value="@{spell_var_description}"><span class="sheet-toggle-description sheet-spell-toggle-button">
           <span class="sheet-en">Description</span>
           <span class="sheet-de">Beschreibung</span>
           <span class="sheet-fr">Description</span>
           <span class="sheet-ru">Описание</span>
         </span>
-        <input type="checkbox" name="attr_spell_toggle_higher_lvl" class="sheet-toggle-spell-higherlvl" value="@{spell_var_higher_lvl}"><span class="sheet-toggle-spell-higherlvl">
+        <input type="checkbox" name="attr_spell_toggle_higher_lvl" class="sheet-toggle-spell-higherlvl sheet-spell-toggle-button" value="@{spell_var_higher_lvl}"><span class="sheet-toggle-spell-higherlvl sheet-spell-toggle-button">
           <span class="sheet-en">Higher Lvl</span>
           <span class="sheet-de">Höheren Stufen</span>
           <span class="sheet-fr">Niv Sup</span>
           <span class="sheet-ru">Выс. Уровень</span>
         </span>
-        <input type="checkbox" name="attr_spell_toggle_higher_lvl_query" class="sheet-toggle-spell-higherlvl-query" value="@{higher_level_query}"><span class="sheet-toggle-spell-higherlvl-query">
+        <input type="checkbox" name="attr_spell_toggle_higher_lvl_query" class="sheet-toggle-spell-higherlvl-query sheet-spell-toggle-button" value="@{higher_level_query}"><span class="sheet-toggle-spell-higherlvl-query sheet-spell-toggle-button">
           <span class="sheet-en">Higher Lvl Query</span>
           <span class="sheet-de">Höheren Stufen Abfrage</span>
           <span class="sheet-fr">Jets Niveau Sup</span>
           <span class="sheet-ru">Эфф. выс. уровня</span>
         </span>
-        <input type="checkbox" name="attr_spell_toggle_output_higher_lvl_query" class="sheet-toggle-spell-output-higherlvl-query sheet-mar-t-md" value="@{spell_var_output_higher_lvl_query}"><span class="sheet-toggle-spell-output-higherlvl-query sheet-mar-t-md">
+        <input type="checkbox" name="attr_spell_toggle_output_higher_lvl_query" class="sheet-toggle-spell-output-higherlvl-query sheet-mar-t-md sheet-spell-toggle-button" value="@{spell_var_output_higher_lvl_query}"><span class="sheet-toggle-spell-output-higherlvl-query sheet-mar-t-md sheet-spell-toggle-button">
           <span class="sheet-en">Output</span>
           <span class="sheet-de">Ausgabe</span>
           <span class="sheet-fr">Affiché</span>
           <span class="sheet-ru">Выводить</span>
         </span>
-        <input type="checkbox" name="attr_spell_toggle_emote" class="sheet-toggle-emote" value="@{spell_var_emote}"><span class="sheet-toggle-emote">
+        <input type="checkbox" name="attr_spell_toggle_emote" class="sheet-toggle-emote sheet-spell-toggle-button" value="@{spell_var_emote}"><span class="sheet-toggle-emote sheet-spell-toggle-button">
           <span class="sheet-en">Emote</span>
           <span class="sheet-de">Emote</span>
           <span class="sheet-fr">Emote</span>
           <span class="sheet-ru">Текст</span>
         </span>
-        <input type="checkbox" name="attr_spell_toggle_attack" class="sheet-toggle-attack" value="@{spell_var_attack}"><span class="sheet-toggle-attack">
+        <input type="checkbox" name="attr_spell_toggle_attack" class="sheet-toggle-attack sheet-spell-toggle-button" value="@{spell_var_attack}"><span class="sheet-toggle-attack sheet-spell-toggle-button">
           <span class="sheet-en">Attack</span>
           <span class="sheet-de">Angriff</span>
           <span class="sheet-fr">Attaque</span>
           <span class="sheet-ru">Атака</span>
         </span>
-        <input type="checkbox" name="attr_spell_toggle_attack_damage" class="sheet-toggle-damage sheet-mar-t-md" value="@{spell_var_attack_damage}"><span class="sheet-toggle-damage sheet-mar-t-md">
+        <input type="checkbox" name="attr_spell_toggle_attack_damage" class="sheet-toggle-damage sheet-mar-t-md sheet-spell-toggle-button" value="@{spell_var_attack_damage}"><span class="sheet-toggle-damage sheet-mar-t-md sheet-spell-toggle-button">
           <span class="sheet-en">Dmg</span>
           <span class="sheet-de">Schad.</span>
           <span class="sheet-fr">Dmg</span>
           <span class="sheet-ru">Урн</span>
         </span>
-        <input type="checkbox" name="attr_spell_toggle_attack_crit" class="sheet-toggle-crit sheet-mar-t-lg" value="@{spell_var_attack_crit}" checked><span class="sheet-toggle-crit sheet-mar-t-lg">
+        <input type="checkbox" name="attr_spell_toggle_attack_crit" class="sheet-toggle-crit sheet-mar-t-lg sheet-spell-toggle-button" value="@{spell_var_attack_crit}" checked><span class="sheet-toggle-crit sheet-mar-t-lg sheet-spell-toggle-button">
           <span class="sheet-en">Crit</span>
           <span class="sheet-de">Crit</span>
           <span class="sheet-fr">Crit</span>
           <span class="sheet-ru">Крит</span>
         </span>
-        <input type="checkbox" name="attr_spell_toggle_attack_second_damage" class="sheet-toggle-second-damage sheet-mar-t-lg" value="@{spell_var_attack_second_damage}"><span class="sheet-toggle-second-damage sheet-mar-t-lg">
+        <input type="checkbox" name="attr_spell_toggle_attack_second_damage" class="sheet-toggle-second-damage sheet-mar-t-lg sheet-spell-toggle-button" value="@{spell_var_attack_second_damage}"><span class="sheet-toggle-second-damage sheet-mar-t-lg sheet-spell-toggle-button">
           <span class="sheet-en">Secondary</span>
           <span class="sheet-de">Secondary</span>
           <span class="sheet-fr">Secondaire</span>
           <span class="sheet-ru">Вторичное</span>
         </span>
-        <input type="checkbox" name="attr_spell_toggle_save" class="sheet-toggle-save" value="@{spell_var_save}"><span class="sheet-toggle-save">
+        <input type="checkbox" name="attr_spell_toggle_save" class="sheet-toggle-save sheet-spell-toggle-button" value="@{spell_var_save}"><span class="sheet-toggle-save sheet-spell-toggle-button">
           <span class="sheet-en">Save</span>
           <span class="sheet-de">Rettung</span>
           <span class="sheet-fr">Sauv</span>
           <span class="sheet-ru">Спас</span>
         </span>
-        <input type="checkbox" name="attr_spell_toggle_save_damage" class="sheet-toggle-sv-damage sheet-mar-t-md" value="@{spell_var_save_damage}"><span class="sheet-toggle-sv-damage sheet-mar-t-md">
+        <input type="checkbox" name="attr_spell_toggle_save_damage" class="sheet-toggle-sv-damage sheet-mar-t-md sheet-spell-toggle-button" value="@{spell_var_save_damage}"><span class="sheet-toggle-sv-damage sheet-mar-t-md sheet-spell-toggle-button">
           <span class="sheet-en">Dmg</span>
           <span class="sheet-de">Schad.</span>
           <span class="sheet-fr">Dmg</span>
           <span class="sheet-ru">Урон</span>
         </span>
-        <input type="checkbox" name="attr_spell_toggle_save_second_damage" class="sheet-toggle-sv-second-damage sheet-mar-t-lg" value="@{spell_var_save_second_damage}"><span class="sheet-toggle-sv-damage sheet-toggle-sv-second-damage sheet-mar-t-lg">
+        <input type="checkbox" name="attr_spell_toggle_save_second_damage" class="sheet-toggle-sv-second-damage sheet-mar-t-lg sheet-spell-toggle-button" value="@{spell_var_save_second_damage}"><span class="sheet-toggle-sv-damage sheet-toggle-sv-second-damage sheet-mar-t-lg sheet-spell-toggle-button">
           <span class="sheet-en">Secondary</span>
           <span class="sheet-de">Secondary</span>
           <span class="sheet-fr">Secondaire</span>
           <span class="sheet-ru">Вторичное</span>
         </span>
-        <input type="checkbox" name="attr_spell_toggle_bonuses" class="sheet-toggle-bonuses" value="@{spell_var_bonuses}"><span class="sheet-toggle-bonuses">
+        <input type="checkbox" name="attr_spell_toggle_bonuses" class="sheet-toggle-bonuses sheet-spell-toggle-button" value="@{spell_var_bonuses}"><span class="sheet-toggle-bonuses sheet-spell-toggle-button">
           <span class="sheet-en">Bonuses</span>
           <span class="sheet-de">Bonuses</span>
           <span class="sheet-fr">Bonus</span>
           <span class="sheet-ru">Бонусы</span>
         </span>
-        <input type="checkbox" name="attr_spell_toggle_healing" class="sheet-toggle-heal" value="@{spell_var_healing}"><span class="sheet-toggle-heal">
+        <input type="checkbox" name="attr_spell_toggle_healing" class="sheet-toggle-heal sheet-spell-toggle-button" value="@{spell_var_healing}"><span class="sheet-toggle-heal sheet-spell-toggle-button">
           <span class="sheet-en">Heal</span>
           <span class="sheet-de">Heilen</span>
           <span class="sheet-fr">Soin</span>
           <span class="sheet-ru">Лечение</span>
         </span>
-        <input type="checkbox" name="attr_spell_toggle_effects" class="sheet-toggle-effects" value="@{spell_var_effects}"><span class="sheet-toggle-effects">
+        <input type="checkbox" name="attr_spell_toggle_effects" class="sheet-toggle-effects sheet-spell-toggle-button" value="@{spell_var_effects}"><span class="sheet-toggle-effects sheet-spell-toggle-button">
           <span class="sheet-en">Effects</span>
           <span class="sheet-de">Effekte</span>
           <span class="sheet-fr">Effets</span>
           <span class="sheet-ru">Эффекты</span>
         </span>
-        <input type="checkbox" name="attr_spell_toggle_source" class="sheet-toggle-spell-source" value="@{spell_var_source}"><span class="sheet-toggle-spell-source">
+        <input type="checkbox" name="attr_spell_toggle_source" class="sheet-toggle-spell-source sheet-spell-toggle-button" value="@{spell_var_source}"><span class="sheet-toggle-spell-source sheet-spell-toggle-button">
           <span class="sheet-en">Source</span>
           <span class="sheet-de">Quelle</span>
           <span class="sheet-fr">Source</span>
           <span class="sheet-ru">Источник</span>
         </span>
-        <input type="checkbox" name="attr_spell_toggle_gained_from" class="sheet-toggle-spell-from" value="@{spell_var_gained_from}"><span class="sheet-toggle-spell-from">
+        <input type="checkbox" name="attr_spell_toggle_gained_from" class="sheet-toggle-spell-from sheet-spell-toggle-button" value="@{spell_var_gained_from}"><span class="sheet-toggle-spell-from sheet-spell-toggle-button">
           <span class="sheet-en">From</span>
           <span class="sheet-de">Von</span>
           <span class="sheet-fr">Origine</span>

--- a/D&D_5e_Shaped/precompiled/pages/spells.html
+++ b/D&D_5e_Shaped/precompiled/pages/spells.html
@@ -22,7 +22,24 @@
   <input type="hidden" name="attr_casting_stat_dc" value="(@{base_spell_dc}+@{casting_stat}+@{PB}[pb])">
   <input type="hidden" name="attr_second_casting_stat_dc" value="(@{base_spell_dc}+@{second_casting_stat}+@{PB}[pb])">
 
-  <h4 class="sheet-center">
+  <input type="checkbox" class="sheet-toggle-display-options">
+  <span class="sheet-toggle-display-options">Display Options</span>
+  <input type="checkbox" class="sheet-toggle-spell-dashboard sheet-display-option" name="attr_display_spell_dashboard" value="1" checked>
+  <span class="sheet-toggle-spell-dashboard sheet-display-option">Dashboard</span>
+  <input type="checkbox" class="sheet-toggle-spell-slots sheet-mar-t-md sheet-display-option" name="attr_display_spell_slots" value="1" checked>
+  <span class="sheet-toggle-spell-slots sheet-mar-t-md sheet-display-option">Slots</span>
+  <input type="checkbox" class="sheet-toggle-sorcery-points sheet-mar-t-md sheet-display-option" name="attr_display_spell_sorcery_points" value="1" checked>
+  <span class="sheet-toggle-sorcery-points sheet-mar-t-md sheet-display-option">Sorcerer</span>
+  <input type="checkbox" class="sheet-toggle-warlock-slots sheet-mar-t-md sheet-display-option" name="attr_display_spell_warlock_slots" value="1" checked>
+  <span class="sheet-toggle-warlock-slots sheet-mar-t-md sheet-display-option">Warlock</span>
+  <input type="checkbox" class="sheet-toggle-spell-filters sheet-display-option" name="attr_display_spell_filters" value="1" checked>
+  <span class="sheet-toggle-spell-filters sheet-display-option">Filters</span>
+  <input type="checkbox" class="sheet-toggle-spell-toggle-buttons sheet-display-option" name="attr_display_spell_toggle_button" value="1" checked>
+  <span class="sheet-toggle-spell-toggle-buttons sheet-display-option">Toggles</span>
+  <input type="checkbox" class="sheet-toggle-spell-unchecked-attrs sheet-display-option" name="attr_display_spell_unchecked_attrs" value="1" checked>
+  <span class="sheet-toggle-spell-unchecked-attrs sheet-display-option">Attrs</span>
+
+  <h4 class="sheet-center sheet-spell-dashboard">
     <span class="sheet-en">Spell Dashboard </span>
     <span class="sheet-de">Zauber Dashboard </span>
     <span class="sheet-fr">Tableau de bord des Sorts </span>
@@ -30,7 +47,7 @@
     <span class="sheet-pictos-custom">t</span>
   </h4>
 
-  <div class="sheet-shaped-row sheet-mar-b-sm">
+  <div class="sheet-shaped-row sheet-mar-b-sm sheet-spell-dashboard">
     <div class="sheet-col-80 sheet-spell-table">
       <div class="sheet-shaped-row sheet-sub-header sheet-relative">
         <div class="sheet-col-07 sheet-offset-18 sheet-vert-bottom sheet-center sheet-small-label sheet-pad-r-sm">
@@ -241,7 +258,7 @@
       <hr>
 
       <div class="sheet-shaped-row">
-        <div class="sheet-col-15 sheet-pad-r-sm">
+        <div class="sheet-col-15 sheet-pad-r-sm sheet-spell-sorcery-points">
           <div class="sheet-sub-header sheet-center">
             <div class="sheet-small-label">
               <span class="sheet-en">Sorcerer</span>
@@ -287,7 +304,7 @@
             </div>
           </div>
         </div>
-        <div class="sheet-col-35 sheet-pad-l-sm sheet-pad-r-sm">
+        <div class="sheet-col-35 sheet-pad-l-sm sheet-pad-r-sm sheet-spell-warlock-slots">
           <div class="sheet-sub-header sheet-center">
             <div class="sheet-small-label">
               <span class="sheet-en">Warlock</span>


### PR DESCRIPTION
PR is as discussed on roll20 forums. One issue I can't quite figure out is the checkbox elements are all slightly offset from the spans, despite the input width and the span width and left-margin all being equal.

![image](http://i.imgur.com/vFShO1H.gif)
