### PR TITLE
Reducing broken decimals for 5e_Shaped inventory weights

### DIFF
--- a/D&D_5e_Shaped/precompiled/components/inventory/inventory.html
+++ b/D&D_5e_Shaped/precompiled/components/inventory/inventory.html
@@ -1,7 +1,7 @@
 <div class="sheet-inventory-row-{{num}}">
   <div class="sheet-shaped-row">
     <div class="sheet-col-05 sheet-vert-middle sheet-inventory-row-number">{{num}}</div>
-    <div class="sheet-col-05 sheet-center sheet-vert-middle"><input type="checkbox" name="attr_inventorycarried{{num}}" value="@{inventoryweight{{num}}}" checked></div>
+    <div class="sheet-col-05 sheet-center sheet-vert-middle"><input type="checkbox" name="attr_inventorycarried{{num}}" value="round(@{inventoryweight{{num}}} * 100)" checked></div>
     <div class="sheet-col-05 sheet-pad-r-sm"><input type="number" name="attr_inventoryqty{{num}}" value="1" min="0" step="1"></div>
     <div class="sheet-col-30 sheet-pad-r-sm"><input type="text" name="attr_inventoryname{{num}}"></div>
     <div class="sheet-col-06 sheet-pad-r-sm"><input type="number" name="attr_inventoryweight{{num}}" value="0" step="0.01"></div>

--- a/D&D_5e_Shaped/precompiled/pages/inventory.html
+++ b/D&D_5e_Shaped/precompiled/pages/inventory.html
@@ -89,7 +89,7 @@
       </div>
     </div>
     <div class="sheet-col-10 sheet-center sheet-pad-r-sm">
-      <input type="number" name="attr_coin_weight" value="((@{CP} + @{SP} + @{EP} + @{GP} + @{PP}) / 50)" disabled="disabled">
+      <input type="number" name="attr_coin_count" value="((@{CP} + @{SP} + @{EP} + @{GP} + @{PP}))" disabled="disabled">
 
       <div class="sheet-small-label">
         <span class="sheet-en">Coin</span>
@@ -109,7 +109,7 @@
       </div>
     </div>
     <div class="sheet-col-30 sheet-center sheet-pad-r-lg">
-      <input type="number" name="attr_total_weight" value="@{inventory_weight} + @{coin_weight} + @{other_weight}" class="sheet-bold" disabled="disabled">
+      <input type="number" name="attr_total_weight" value="(((@{inventory_weight}) + (@{coin_count} * 2)) / 100) + (@{other_weight})" class="sheet-bold" disabled="disabled">
 
       <div class="sheet-small-label sheet-bold">
         <span class="sheet-en">Total</span>


### PR DESCRIPTION
My players have complained quite a bit about the oddball repeating decimals that pop up in the inventory weights quite regularly.
The problem occurs because binary cannot represent most common decimals (e.g. 0.3) exactly, so a great many calculations produce oddball results. Simply doing all of the math as integer math in hundredths fixes this issue.
This patch changes the calculation by multiplying by 100 at the source of the inventory values, keeping coins an integer count until the final calculation, then dividing by 100 at the end.
I hope this significantly reduces the binary fraction errors that currently plague the inventory weight calculation. I haven't thoroughly tested this, but it seems to work in many cases (assuming I transcribed things correctly from the mingled sheet to the source components).
Ideally there would be a more sweeping change to just not use decimals at all, since this still ends up with some weird calculation errors, but it would require some visible changes to the sheet to do the more comprehensive change, and visible changes might cause issues for campaigns using the sheet.
