### PR TITLE
Bugfix: should be an array of spell objects

### DIFF
--- a/D&D_5e_Reshaped/precompiled/components/sheetWorkers.js
+++ b/D&D_5e_Reshaped/precompiled/components/sheetWorkers.js
@@ -4819,14 +4819,15 @@ const importData = () => {
         }
       }
       if (importObject.spells) {
-        for (const prop in importObject.spells) {
-          if (importObject.spells.hasOwnProperty(prop)) {
-            const newRowId = generateRowID();
-            const repeatingString = `repeating_spell_${newRowId}_`;
-
-            finalSetAttrs[`${repeatingString}${prop}`] = importObject.spells[prop];
+        importObject.spells.forEach(spell => {
+          const newRowId = generateRowID();
+          const repeatingString = `repeating_spell_${newRowId}_`;
+          for (const prop in spell) {
+            if (spell.hasOwnProperty(prop)) {
+              finalSetAttrs[`${repeatingString}${prop}`] = spell[prop];
+            }
           }
-        }
+        });
       }
       finalSetAttrs.import_data = '';
       finalSetAttrs.import_data_present = 'off';


### PR DESCRIPTION
Sorry, a bit of a miscommunication earlier - only just looked at your changes. You fixed the npc one (which was broken) but broke the spells one - there's one npc but spells is an array. I've used forEach because it is a proper array - but I don't know if you'd rather use a loop here as well. Anyway, you get the idea.
