### PR TITLE
Add lair actions and regional effects parsing

### DIFF
--- a/D&D_5e_Reshaped/precompiled/components/sheetWorkers.js
+++ b/D&D_5e_Reshaped/precompiled/components/sheetWorkers.js
@@ -1,3 +1,4 @@
+/* global setAttrs:false, getAttrs:false, on:false, getSectionIDs:false, generateRowID:false */
 'use strict';
 
 const currentVersion = '2.2.24';
@@ -3961,6 +3962,8 @@ const updateNPCContent = () => {
 
   getAttrs(collectionArray, (v) => {
     let content = v.content_srd;
+    let regionalEffects;
+    let lairActions;
     let legendaryActions;
     let reactions;
     let actions;
@@ -3973,6 +3976,32 @@ const updateNPCContent = () => {
     setDefaultAbility(v, finalSetAttrs);
 
     if (exists(content)) {
+      if (content.indexOf('Regional Effects') !== -1) {
+        const regionalEffectsSplit = content.split(/Regional Effects\n/);
+        regionalEffects = regionalEffectsSplit[1];
+        content = regionalEffectsSplit[0];
+      }
+      if (exists(regionalEffects)) {
+        const regionalEffectsList = regionalEffects.split(/\*\*/);
+        regionalEffectsList.slice(1, -1).forEach((regionalEffect) => {
+          newRowId = generateRowID();
+          repeatingString = `repeating_regionaleffect_${newRowId}_`;
+          finalSetAttrs[`${repeatingString}freetext`] = regionalEffect.trim();
+        });
+        finalSetAttrs.regional_effects_fade = regionalEffectsList.slice(-1)[0];
+      }
+      if (content.indexOf('Lair Actions') !== -1) {
+        const lairActionsSplit = content.split(/Lair Actions\n/);
+        lairActions = lairActionsSplit[1];
+        content = lairActionsSplit[0];
+      }
+      if (exists(lairActions)) {
+        lairActions.split(/\*\*/).slice(1).forEach((lairAction) => {
+          newRowId = generateRowID();
+          repeatingString = `repeating_lairaction_${newRowId}_`;
+          finalSetAttrs[`${repeatingString}freetext`] = lairAction.trim();
+        });
+      }
       if (content.indexOf('Legendary Actions') !== -1) {
         const legendaryActionsSplit = content.split(/Legendary Actions\n/);
         legendaryActions = legendaryActionsSplit[1];

--- a/D&D_5e_Reshaped/precompiled/package.json
+++ b/D&D_5e_Reshaped/precompiled/package.json
@@ -6,23 +6,23 @@
   "main": "gulpfile.js",
   "dependencies": {},
   "devDependencies": {
-    "babel-eslint": "4.1.6",
+    "babel-eslint": "^6.0.0",
+    "babel-preset-es2015": "6.6.0",
     "eslint-config-airbnb": "3.1.0",
     "gulp": "^3.9.0",
     "gulp-babel": "6.1.2",
     "gulp-change": "^1.0.0",
     "gulp-concat": "^2.6.0",
+    "gulp-eslint": "1.1.1",
     "gulp-include": "^2.1.0",
     "gulp-inject": "^3.0.0",
-    "gulp-eslint": "1.1.1",
     "gulp-minify-css": "^1.2.2",
     "gulp-minify-html": "^1.0.4",
     "gulp-rename": "^1.2.2",
     "gulp-replace-task": "^0.11.0",
     "gulp-sass": "^2.2.0",
     "gulp-sass-lint": "^1.1.1",
-    "gulp-wrapper": "1.0.0",
-    "babel-preset-es2015": "6.6.0"
+    "gulp-wrapper": "1.0.0"
   },
   "scripts": {},
   "repository": {


### PR DESCRIPTION
Also upgraded babel-eslint in package.json to stop it breaking on lint - not sure if it was working for you/you had a different version installed somehow, but it's a known bug that was fixed more recently: https://github.com/babel/babel-eslint/issues/243
