### PR TITLE
Add parsed speed attribute

### DIFF
--- a/D&D_5e_Reshaped/precompiled/components/sheetWorkers.js
+++ b/D&D_5e_Reshaped/precompiled/components/sheetWorkers.js
@@ -4442,6 +4442,10 @@ const updateSpeed = () => {
 
   getAttrs(collectionArray, (v) => {
     finalSetAttrs.npc_speed = v.npc_speed.toLowerCase();
+    const match = finalSetAttrs.npc_speed.match(/^\s*(\d+)\s*ft/);
+    if (match) {
+      finalSetAttrs.speed = match[1];
+    }
     setFinalAttrs(v, finalSetAttrs);
   });
 };


### PR DESCRIPTION
- Various people have said they like to have speed as one of their token bars
  Don't really see any harm in the change - it's obviously only part of the story for creatures with multiple speeds, but for the majority of cases it's useful to have a single comparable value that can be used for quick reference as to movement speed
